### PR TITLE
Several optimizations

### DIFF
--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -65,10 +65,19 @@ namespace Caramel{
         Float tmin = Float0;
         Float tmax = INF;
         for(Index i=0;i<3;i++){
-            Float t1 = (m_min[i] - ray.m_o[i]) / ray.m_d[i];
-            Float t2 = (m_max[i] - ray.m_o[i]) / ray.m_d[i];
-            tmin = std::min(std::max(t1, tmin), std::max(t2, tmin));
-            tmax = std::max(std::min(t1, tmax), std::min(t2, tmax));
+            const Float t1 = (m_min[i] - ray.m_o[i]) / ray.m_d[i];
+            const Float t2 = (m_max[i] - ray.m_o[i]) / ray.m_d[i];
+            // Using ternary operator seems faster than std::min/max in debug config
+            /* tmin */{
+                const Float a = (t1 > tmin ? t1 : tmin);
+                const Float b = (t2 > tmin ? t2 : tmin);
+                tmin = a > b ? b : a;
+            }
+            /* tmax */{
+                const Float a = (t1 > tmax ? tmax : t1);
+                const Float b = (t2 > tmax ? tmax : t2);
+                tmax = a > b ? a : b;
+            }
         }
         return {tmin <= tmax, tmin, tmax};
     }

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -91,13 +91,13 @@ namespace Caramel{
         for(Index depth=0;depth<m_max_depth;depth++){
             auto [is_hit, info] = scene.ray_intersect(ray);
 
-            const Shape *shape = scene.m_meshes[info.idx];
-            const BSDF *shape_bsdf = shape->get_bsdf();
-            const Vector3f local_ray_dir = info.sh_coord.to_local(ray.m_d);
-
             if(!is_hit){
                 break;
             }
+
+            const Shape *shape = scene.m_meshes[info.idx];
+            const BSDF *shape_bsdf = shape->get_bsdf();
+            const Vector3f local_ray_dir = info.sh_coord.to_local(ray.m_d);
 
             if(shape->is_light()){
                 if(depth == 0 || from_specular){

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -97,14 +97,19 @@ namespace Caramel{
 
     std::tuple<bool, RayIntersectInfo> Octree::Node::ray_intersect_branch(const Ray &ray, const OBJMesh &shape){
         // sort childs
-        std::array<Index, 8> sorted_idx{0,1,2,3,4,5,6,7};
+        using idx_tmin = std::pair<Index, Float>;
+        std::array<idx_tmin, 8> sorted_idx;
+        for(Index i=0;i<8;i++){
+            sorted_idx[i] = {i, std::get<1>(m_childs[i].m_aabb.ray_intersect(ray))};
+        }
+
         std::sort(sorted_idx.begin(), sorted_idx.end(),
-                  [&](Index a, Index b)->bool{
-                      return std::get<1>(m_childs[a].m_aabb.ray_intersect(ray)) < std::get<1>(m_childs[b].m_aabb.ray_intersect(ray));
+                  [&](const idx_tmin &a, const idx_tmin &b)->bool{
+                      return a.second < b.second;
                   });
 
         for(auto i : sorted_idx){
-            auto [is_intersect, tmp_info] = m_childs[i].ray_intersect(ray, shape);
+            auto [is_intersect, tmp_info] = m_childs[i.first].ray_intersect(ray, shape);
             if (is_intersect) {
                 return{true, tmp_info};
             }


### PR DESCRIPTION
- `std::min/max` seems slower than ternary operator in my environment (debug config, Apple Silicon).
- `nullptr` dereferencing occurs if ray does not intersect.
- Reduce unnecessary `AABB::ray_intersect()` function call during octree node sorting

These fixes reduce render time about 25% in my env
