### PR TITLE
Fix wrong intersection from octree

### DIFF
--- a/include/shape.h
+++ b/include/shape.h
@@ -93,8 +93,12 @@ namespace Caramel{
         // point, normal, probability
         std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const override;
 
-        inline Vector3f point(Index i) const;
-        inline Vector3f normal(Index i) const;
+        inline Vector3f point(Index i) const{
+            return i == 0 ? m_p0 : i == 1 ? m_p1 : m_p2;
+        }
+        inline Vector3f normal(Index i) const{
+            return i == 0 ? m_n0 : i == 1 ? m_n1 : m_n2;
+        }
 
     private:
         Vector3f m_p0, m_p1, m_p2;

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -31,13 +31,13 @@
 namespace Caramel{
     AABB::AABB() = default;
     AABB::AABB(const Vector3f &p1, const Vector3f &p2) {
-        m_min = Vector3f{std::min({p1[0], p2[0]}),
-                         std::min({p1[1], p2[1]}),
-                         std::min({p1[2], p2[2]})};
+        m_min = Vector3f{std::min(p1[0], p2[0]),
+                         std::min(p1[1], p2[1]),
+                         std::min(p1[2], p2[2])};
 
-        m_max = Vector3f{std::max({p1[0], p2[0]}),
-                         std::max({p1[1], p2[1]}),
-                         std::max({p1[2], p2[2]})};
+        m_max = Vector3f{std::max(p1[0], p2[0]),
+                         std::max(p1[1], p2[1]),
+                         std::max(p1[2], p2[2])};
     }
 
     bool AABB::is_overlap(const AABB &aabb) const{

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -96,27 +96,20 @@ namespace Caramel{
     }
 
     std::tuple<bool, RayIntersectInfo> Octree::Node::ray_intersect_branch(const Ray &ray, const OBJMesh &shape){
-        // sort childs
-        using idx_tmin = std::pair<Index, Float>;
-        std::array<idx_tmin, 8> sorted_idx;
-        for(Index i=0;i<8;i++){
-            sorted_idx[i] = {i, std::get<1>(m_childs[i].m_aabb.ray_intersect(ray))};
-        }
+        RayIntersectInfo info;
+        bool is_hit = false;
 
-        std::sort(sorted_idx.begin(), sorted_idx.end(),
-                  [&](const idx_tmin &a, const idx_tmin &b)->bool{
-                      return a.second < b.second;
-                  });
-
-        for(auto i : sorted_idx){
-            auto [is_intersect, tmp_info] = m_childs[i.first].ray_intersect(ray, shape);
+        for(int i=0;i<8;i++){
+            auto [is_intersect, tmp_info] = m_childs[i].ray_intersect(ray, shape);
             if (is_intersect) {
-                return{true, tmp_info};
+                is_hit = true;
+                if (info.t > tmp_info.t) {
+                    info = tmp_info;
+                }
             }
         }
 
-        RayIntersectInfo info;
-        return {false, info};
+        return {is_hit, info};
     }
 
     std::tuple<bool, RayIntersectInfo> Octree::Node::ray_intersect(const Ray &ray, const OBJMesh &shape){

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -64,9 +64,7 @@ namespace Caramel{
             return;
         }
 
-        if(m_triangle_indices.size() > MAX_TRIANGLE_NUM){
-            construct_children(shape);
-        }
+        construct_children(shape);
 
         if(depth == 0 && m_childs.size() == 8){
             parallel_for(0, 8, [&](int i){
@@ -75,7 +73,9 @@ namespace Caramel{
         }
         else{
             for(auto &c : m_childs){
-                c.construct_children_recursively(shape, depth + 1);
+                if(c.m_triangle_indices.size() > MAX_TRIANGLE_NUM){
+                    c.construct_children_recursively(shape, depth + 1);
+                }
             }
         }
     }

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -49,7 +49,6 @@ namespace Caramel{
         for(auto ti : m_triangle_indices){
             const Triangle tri = shape.get_triangle(ti);
             for(int i=0;i<8;i++){
-                // can be replaced to tri.is_overlab, not using aabb
                 if(m_childs[i].m_aabb.is_overlap(tri.get_aabb())){
                     m_childs[i].m_triangle_indices.push_back(ti);
                 }

--- a/src/shapes/triangle.cpp
+++ b/src/shapes/triangle.cpp
@@ -66,42 +66,24 @@ namespace Caramel {
                 Float1 / get_area()};
     }
 
-    inline Vector3f Triangle::point(Index i) const {
-        return i == 0 ? m_p0 : i == 1 ? m_p1 : m_p2;
-    }
-
-    inline Vector3f Triangle::normal(Index i) const {
-        return i == 0 ? m_n0 : i == 1 ? m_n1 : m_n2;
-    }
-
     // u, v, t
     std::tuple<bool, RayIntersectInfo> Triangle::ray_intersect(const Ray &ray) const {
 
-        auto [u, v, t] = watertight_intersection(ray, m_p0, m_p1, m_p2);
+        auto [u, v, t] = moller_trumbore(ray, m_p0, m_p1, m_p2);
 
         if(u==-Float1 && v==-Float1 && t==-Float1){
             return {false, RayIntersectInfo()};
         }
 
-        // Intersect
-        Vector3f hitpos = interpolate(m_p0, m_p1, m_p2, u, v);
-
-
         RayIntersectInfo ret;
-        ret.p = hitpos;
         ret.t = t;
         ret.u = u;
         ret.v = v;
-
-        if(is_vn_exists){
-            Vector3f shn = interpolate(m_n0, m_n1, m_n2, u, v);
-            ret.sh_coord = Coordinate(shn.normalize());
-        }
-        else{
-            const Vector3f E1 = m_p1 - m_p0;
-            const Vector3f E2 = m_p2 - m_p0;
-            ret.sh_coord = Coordinate(cross(E1, E2).normalize());
-        }
+        ret.p = interpolate(m_p0, m_p1, m_p2, u, v);
+        
+        const Vector3f n = is_vn_exists ? interpolate(m_n0, m_n1, m_n2, u, v).normalize() :
+                                          cross(m_p1 - m_p0, m_p2 - m_p0).normalize();
+        ret.sh_coord = Coordinate(n);
 
         return {true, ret};
     }


### PR DESCRIPTION
`Octree::ray_intersect()` sometime returns wrong value because of `Octree::Node::ray_intersect_branch()`, which skips ray intersection in the certain condition. This PR fixes that method to not skip intersection test earlier.

