### PR TITLE
Reduce unnecessary ray casting

### DIFF
--- a/include/acceleration.h
+++ b/include/acceleration.h
@@ -84,7 +84,7 @@ namespace Caramel{
         void build() override;
         std::tuple<bool, RayIntersectInfo> ray_intersect(const Ray &ray) override;
 
-        static constexpr Index MAX_DEPTH = 10;
+        static constexpr Index MAX_DEPTH = 7;
         static constexpr Index MAX_TRIANGLE_NUM = 30;
         Node m_head;
     };

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -30,6 +30,7 @@
 #include <common.h>
 #include <parallel_for.h>
 #include <ray.h>
+#include <logger.h>
 #include <rayintersectinfo.h>
 #include <shape.h>
 
@@ -100,11 +101,13 @@ namespace Caramel{
         bool is_hit = false;
 
         for(const auto &child : m_childs){
-            const auto &[is_intersect, tmp_info] = child.ray_intersect(ray, shape);
-            if (is_intersect) {
-                is_hit = true;
-                if (info.t > tmp_info.t) {
-                    info = tmp_info;
+            if(get<1>(child.m_aabb.ray_intersect(ray)) <= info.t) {
+                const auto &[is_intersect, tmp_info] = child.ray_intersect(ray, shape);
+                if (is_intersect) {
+                    is_hit = true;
+                    if (info.t > tmp_info.t) {
+                        info = tmp_info;
+                    }
                 }
             }
         }

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -30,7 +30,6 @@
 #include <common.h>
 #include <parallel_for.h>
 #include <ray.h>
-#include <logger.h>
 #include <rayintersectinfo.h>
 #include <shape.h>
 

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -48,12 +48,14 @@ namespace Caramel{
         RayIntersectInfo info = RayIntersectInfo();
 
         for(int i=0;i<m_meshes.size();i++){
-            auto [hit, tmp_info] = m_meshes[i]->ray_intersect(ray);
-            if(hit){
-                is_hit = true;
-                if(info.t >= tmp_info.t){
-                    info = tmp_info;
-                    info.idx = i;
+            if(get<1>(m_meshes[i]->get_aabb().ray_intersect(ray)) <= info.t){
+                auto [hit, tmp_info] = m_meshes[i]->ray_intersect(ray);
+                if(hit){
+                    is_hit = true;
+                    if(info.t >= tmp_info.t){
+                        info = tmp_info;
+                        info.idx = i;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ray casting is not necessary under certain conditions... Render time reduces about 20% in a complex scene