### PR TITLE
Calibrate camera up vector 

### DIFF
--- a/include/camera.h
+++ b/include/camera.h
@@ -55,12 +55,15 @@ namespace Caramel{
     private:
         const Vector3f m_pos;
         const Vector3f m_dir;
-        const Vector3f m_up;
+        Vector3f m_up;
         Vector3f m_left;
         const Float m_fov_x;
         Index m_w, m_h;
         Float m_cam_space_dir_z;
         Float m_ratio;
+        Float m_near;
+        Float m_far;
+        Matrix44f m_sample_to_camera;
         Matrix44f m_cam_to_world;
     };
 }

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -25,6 +25,7 @@
 #include <camera.h>
 
 #include <common.h>
+#include <transform.h>
 #include <ray.h>
 
 namespace Caramel{
@@ -32,9 +33,10 @@ namespace Caramel{
     // Perspective camera
     Camera::Camera(const Vector3f &pos, const Vector3f &dir, const Vector3f &up,
                    Index w, Index h, Float fov_x)
-        : m_pos{pos}, m_dir{dir.normalize()}, m_up(up.normalize()), m_w{w}, m_h{h}, m_fov_x{fov_x} {
+        : m_pos{pos}, m_dir{dir.normalize()}, m_up(up.normalize()), m_w{w}, m_h{h}, m_fov_x{fov_x}, m_near{1e-4}, m_far{1000} {
         // right-handed coord
         m_left = cross(m_up, m_dir);
+        m_up = cross(m_dir, m_left);
 
         m_cam_to_world = Matrix44f::from_cols(
                 Vector4f{m_left[0], m_left[1], m_left[2], Float0},
@@ -44,15 +46,28 @@ namespace Caramel{
         );
 
         m_ratio = static_cast<Float>(m_w) / static_cast<Float>(m_h);
-        // m_ratio / tangent of half fov
-        m_cam_space_dir_z = m_ratio / tan(m_fov_x * PI / (360));
+
+        const Float tmp1 = Float1 / (m_far - m_near);
+        const Float cot = Float1 / tan(deg_to_rad(m_fov_x * Float0_5));
+
+        const Matrix44f perspective{   cot, Float0,       Float0,                 Float0,
+                                    Float0,    cot,       Float0,                 Float0,
+                                    Float0, Float0, m_far * tmp1, -m_near * m_far * tmp1,
+                                    Float0, Float0,       Float1,                 Float0};
+
+        const Matrix44f camera_to_sample = scale(-Float0_5, -Float0_5 * m_ratio, Float1) *
+                                           translate(-Float1, -Float1/m_ratio, Float0) *
+                                           perspective;
+
+        m_sample_to_camera = Inverse(camera_to_sample).eval();
     }
 
     [[nodiscard]] Ray Camera::sample_ray(Float w, Float h) const{
-        const Vector4f local_d{-(w / static_cast<Float>(m_w) - Float0_5) * 2 * m_ratio,
-                               -(h / static_cast<Float>(m_h) - Float0_5) * 2 ,
-                               m_cam_space_dir_z,
-                               Float0};
+        Vector4f local_d = (m_sample_to_camera * Vector4f(w / static_cast<Float>(m_w),
+                                                          h / static_cast<Float>(m_h),
+                                                          Float0, Float1));
+        local_d[3] = Float0;
+        local_d = local_d.normalize();
 
         const Vector3f d = Block<0,0,3,1>(m_cam_to_world * local_d);
 


### PR DESCRIPTION
, fix to use projection matrix, and add `near`/`far` parameter for further improvements

before  (compare with mitsuba3)
<img width="1227" alt="스크린샷 2024-02-21 오전 12 16 55" src="https://github.com/pjessesco/caramel/assets/11532321/206c54b2-7bcb-4270-8dd0-d9796dae98f8">


after
<img width="1227" alt="스크린샷 2024-02-21 오전 12 17 13" src="https://github.com/pjessesco/caramel/assets/11532321/f6fb3de9-1f02-4fd9-a07c-ccf872ac76b9">
