### PR TITLE
Optimize octree 

### DIFF
--- a/include/aabb.h
+++ b/include/aabb.h
@@ -52,6 +52,15 @@ namespace Caramel{
                      std::max(a.m_max[2], b.m_max[2])}};
         }
 
+        static AABB overlapped(const AABB &a, const AABB &b) {
+            return {{std::max(a.m_min[0], b.m_min[0]),
+                     std::max(a.m_min[1], b.m_min[1]),
+                     std::max(a.m_min[2], b.m_min[2])},
+                    {std::min(a.m_max[0], b.m_max[0]),
+                     std::min(a.m_max[1], b.m_max[1]),
+                     std::min(a.m_max[2], b.m_max[2])}};
+        }
+
         std::pair<AABB, AABB> split(int axis) const;
 
         int longest_axis() const;

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -58,6 +58,15 @@ namespace Caramel{
 
         m_childs.erase(std::remove_if(m_childs.begin(), m_childs.end(), [](const Octree::Node &node){return node.m_triangle_indices.empty();}), m_childs.end());
         m_triangle_indices.clear();
+
+        // Shrink aabb as possible
+        for (auto &child : m_childs) {
+            AABB shrinked_aabb = shape.get_triangle(child.m_triangle_indices[0]).get_aabb();
+            for (auto tri : child.m_triangle_indices) {
+                shrinked_aabb = AABB::merge(shrinked_aabb, shape.get_triangle(tri).get_aabb());
+            }
+            child.m_aabb = AABB::overlapped(shrinked_aabb, child.m_aabb);
+        }
     }
 
     void Octree::Node::construct_children_recursively(const OBJMesh &shape, int depth){

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -50,8 +50,9 @@ namespace Caramel{
         for(auto ti : m_triangle_indices){
             const Triangle &tri = shape.get_triangle(ti);
             for(auto &child : m_childs){
-                if(child.m_aabb.is_overlap(tri.get_aabb())){
+                if(child.m_aabb.is_contain(tri.get_center())){
                     child.m_triangle_indices.emplace_back(ti);
+                    break;
                 }
             }
         }
@@ -65,7 +66,7 @@ namespace Caramel{
             for (auto tri : child.m_triangle_indices) {
                 shrinked_aabb = AABB::merge(shrinked_aabb, shape.get_triangle(tri).get_aabb());
             }
-            child.m_aabb = AABB::overlapped(shrinked_aabb, child.m_aabb);
+            child.m_aabb = shrinked_aabb;
         }
     }
 


### PR DESCRIPTION
- Shrink node AABB as possible
- Remove redundant triangle saving logic

before

<img width="475" alt="before" src="https://github.com/user-attachments/assets/f3006288-5629-4566-a0cb-51385faccc3d" />

after

<img width="374" alt="스크린샷 2025-05-05 오후 9 59 24" src="https://github.com/user-attachments/assets/2c7e49be-423d-4940-bee5-9a17a87d74bd" />

