### PR TITLE
Add id-based bsdf scene description

### DIFF
--- a/.github/workflows/build_test_build_macos_clang.yml
+++ b/.github/workflows/build_test_build_macos_clang.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  LDFLAGS: "-L/opt/homebrew/opt/llvm/lib/c++ -L/opt/homebrew/opt/llvm/lib/unwind -lunwind"
 
 jobs:
   build:

--- a/include/scene_parser.h
+++ b/include/scene_parser.h
@@ -28,6 +28,7 @@
 #include <ranges>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include <common.h>
 
@@ -58,6 +59,8 @@ namespace Caramel{
         std::vector<Light*> parse_lights() const;
 
     private:
+        void parse_bsdfs_map();
+
         Shape* parse_shape(const Json &shape_json) const;
 
         Light* parse_light(const Json &light_json) const;
@@ -86,6 +89,7 @@ namespace Caramel{
         Matrix44f parse_matrix44f(const Json &parent, const std::string &key) const;
 
         Json m_scene_json;
+        std::unordered_map<std::string, BSDF*> m_bsdf_map;
     };
 
 }

--- a/include/scene_parser.h
+++ b/include/scene_parser.h
@@ -50,6 +50,8 @@ namespace Caramel{
     public:
         explicit SceneParser(const std::filesystem::path &path);
 
+        void parse_bsdfs_map();
+
         Integrator* parse_integrator() const;
 
         Camera* parse_camera() const;
@@ -59,8 +61,6 @@ namespace Caramel{
         std::vector<Light*> parse_lights() const;
 
     private:
-        void parse_bsdfs_map();
-
         Shape* parse_shape(const Json &shape_json) const;
 
         Light* parse_light(const Json &light_json) const;

--- a/include/shape.h
+++ b/include/shape.h
@@ -84,14 +84,14 @@ namespace Caramel{
 
     class Triangle final : public Shape{
     public:
-        Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2);
+        Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2, BSDF *bsdf);
 
         Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
-                 const Vector3f &n0, const Vector3f &n1, const Vector3f &n2);
+                 const Vector3f &n0, const Vector3f &n1, const Vector3f &n2, BSDF *bsdf);
 
         Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
                  const Vector3f &n0, const Vector3f &n1, const Vector3f &n2,
-                 const Vector2f &uv0, const Vector2f &uv1, const Vector2f &uv2);
+                 const Vector2f &uv0, const Vector2f &uv1, const Vector2f &uv2, BSDF *bsdf);
 
         // u, v, t
         std::pair<bool, RayIntersectInfo> ray_intersect(const Ray &ray, Float maxt) const override;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -37,9 +37,10 @@ namespace Caramel{
         // Set current path
         std::filesystem::current_path(scene_path.parent_path());
 
-        const SceneParser parser(scene_path);
+        SceneParser parser(scene_path);
         Integrator *integrator = parser.parse_integrator();
         Camera *cam = parser.parse_camera();
+        parser.parse_bsdfs_map();
         const std::vector<Shape*> shapes = parser.parse_shapes();
         const std::vector<Light*> lights = parser.parse_lights();
 

--- a/src/scene_parser.cpp
+++ b/src/scene_parser.cpp
@@ -45,7 +45,6 @@ namespace Caramel{
         
         std::ifstream stream(path);
         m_scene_json = Json::parse(stream);
-        parse_bsdfs_map();
     }
 
     void SceneParser::parse_bsdfs_map() {

--- a/src/scene_parser.cpp
+++ b/src/scene_parser.cpp
@@ -45,6 +45,30 @@ namespace Caramel{
         
         std::ifstream stream(path);
         m_scene_json = Json::parse(stream);
+        parse_bsdfs_map();
+    }
+
+    void SceneParser::parse_bsdfs_map() {
+        if(!m_scene_json.contains("bsdfs")){
+            return;
+        }
+        const Json bsdfs = m_scene_json["bsdfs"];
+        if(bsdfs.is_array()){
+            for(const auto &b : bsdfs){
+                if(!b.contains("id")){
+                    CRM_ERROR("BSDF in bsdfs list must have an id : " + to_string(b));
+                }
+                const std::string id = parse_string(b, "id");
+                if(m_bsdf_map.find(id) != m_bsdf_map.end()){
+                    CRM_ERROR("Duplicated BSDF id : " + id);
+                }
+                
+                // Wrap to match parse_bsdf expectation
+                Json wrapper;
+                wrapper["bsdf"] = b;
+                m_bsdf_map[id] = parse_bsdf(wrapper);
+            }
+        }
     }
 
     Integrator* SceneParser::parse_integrator() const {
@@ -159,12 +183,14 @@ namespace Caramel{
                                                parse_vector3f(shape_json, "p2"),
                                                parse_vector3f(shape_json, "n0"),
                                                parse_vector3f(shape_json, "n1"),
-                                               parse_vector3f(shape_json, "n2"));
+                                               parse_vector3f(shape_json, "n2"),
+                                               parse_bsdf(shape_json));
             }
             else{
                 return Shape::Create<Triangle>(parse_vector3f(shape_json, "p0"),
                                                parse_vector3f(shape_json, "p1"),
-                                               parse_vector3f(shape_json, "p2"));
+                                               parse_vector3f(shape_json, "p2"),
+                                               parse_bsdf(shape_json));
             }
         }
 
@@ -198,6 +224,15 @@ namespace Caramel{
 
     BSDF* SceneParser::parse_bsdf(const SceneParser::Json &bsdf_json) const {
         const Json child = get_unique_first_elem(bsdf_json, "bsdf");
+
+        if(child.is_string()){
+            const std::string id = child;
+            if(m_bsdf_map.find(id) == m_bsdf_map.end()){
+                CRM_ERROR("BSDF id not found : " + id);
+            }
+            return m_bsdf_map.at(id);
+        }
+
         const std::string type = parse_string(child, "type");
         if(type == "diffuse"){
             return child.contains("albedo") ? BSDF::Create<Diffuse>(parse_vector3f(child, "albedo")) :

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -180,19 +180,22 @@ namespace Caramel {
                                 m_normals[m_normal_indices[i][2]],
                                 m_tex_coords[m_tex_coord_indices[i][0]],
                                 m_tex_coords[m_tex_coord_indices[i][1]],
-                                m_tex_coords[m_tex_coord_indices[i][2]]);
+                                m_tex_coords[m_tex_coord_indices[i][2]],
+                                get_bsdf());
             }
             return Triangle(m_vertices[m_vertex_indices[i][0]],
                             m_vertices[m_vertex_indices[i][1]],
                             m_vertices[m_vertex_indices[i][2]],
                             m_normals[m_normal_indices[i][0]],
                             m_normals[m_normal_indices[i][1]],
-                            m_normals[m_normal_indices[i][2]]);
+                            m_normals[m_normal_indices[i][2]],
+                            get_bsdf());
         }
         else{
             return Triangle(m_vertices[m_vertex_indices[i][0]],
                             m_vertices[m_vertex_indices[i][1]],
-                            m_vertices[m_vertex_indices[i][2]]);
+                            m_vertices[m_vertex_indices[i][2]],
+                            get_bsdf());
         }
     }
 }

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -181,11 +181,13 @@ namespace Caramel {
                             m_vertices[idx[2]],
                             m_normals[idx[0]],
                             m_normals[idx[1]],
-                            m_normals[idx[2]]);
+                            m_normals[idx[2]],
+                            get_bsdf());
         } else {
             return Triangle(m_vertices[idx[0]],
                             m_vertices[idx[1]],
-                            m_vertices[idx[2]]);
+                            m_vertices[idx[2]],
+                            get_bsdf());
         }
     }
 }

--- a/src/shapes/triangle.cpp
+++ b/src/shapes/triangle.cpp
@@ -32,17 +32,17 @@
 #include <rayintersectinfo.h>
 
 namespace Caramel {
-    Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2)
-        : Shape(nullptr, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, is_vn_exists{false}, is_tx_exists{false} {}
+    Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2, BSDF *bsdf)
+        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, is_vn_exists{false}, is_tx_exists{false} {}
 
     Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
-                       const Vector3f &n0, const Vector3f &n1, const Vector3f &n2)
-        : Shape(nullptr, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{false} {}
+                       const Vector3f &n0, const Vector3f &n1, const Vector3f &n2, BSDF *bsdf)
+        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{false} {}
 
     Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
                        const Vector3f &n0, const Vector3f &n1, const Vector3f &n2,
-                       const Vector2f &uv0, const Vector2f &uv1, const Vector2f &uv2)
-        : Shape(nullptr, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{true},
+                       const Vector2f &uv0, const Vector2f &uv1, const Vector2f &uv2, BSDF *bsdf)
+        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{true},
           m_uv0{uv0}, m_uv1{uv1}, m_uv2{uv2} {}
 
     AABB Triangle::get_aabb() const{


### PR DESCRIPTION
before : 

```
 "shape": [
    {
        "type": "ply",
        "path": "path1",
        "bsdf": {
            "id": "mat-Gray",
            "type": "diffuse",
            "albedo": [0.296138, 0.323143, 0.391572]
        },
    },
    {
        "type": "ply",
        "path": "path2",
        "bsdf": {
            "id": "mat-Gray",
            "type": "diffuse",
            "albedo": [0.296138, 0.323143, 0.391572]
        },
    },
    ...
]
```

after : 

```
"bsdfs": [
    {
        "id": "mat-Gray",
        "type": "diffuse",
        "albedo": [0.296138, 0.323143, 0.391572]
    },
    ...
],
 "shape": [
    {
        "type": "ply",
        "path": "path1",
        "bsdf": "mat-Gray"
    },
    {
        "type": "ply",
        "path": "path2",
        "bsdf": "mat-Gray"
    },
    ...
]
```
