### PR TITLE
Remove `TriangleMesh::get_triangle()` to avoid unnecessary object instantiation

### DIFF
--- a/include/shape.h
+++ b/include/shape.h
@@ -121,8 +121,11 @@ namespace Caramel{
     class TriangleMesh : public Shape{
     public:
         using Shape::Shape;
-        virtual Triangle get_triangle(Index i) const = 0;
         virtual Index get_triangle_num() const = 0;
+        virtual std::pair<bool, RayIntersectInfo> get_triangle_ray_intersect(Index i, const Ray &ray, Float maxt) const = 0;
+        virtual AABB get_triangle_aabb(Index i) const = 0;
+        virtual Float get_triangle_area(Index i) const = 0;
+        virtual std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const = 0;
     };
 
     class OBJMesh final : public TriangleMesh{
@@ -136,7 +139,10 @@ namespace Caramel{
         std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const override;
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const override;
 
-        Triangle get_triangle(Index i) const override;
+        std::pair<bool, RayIntersectInfo> get_triangle_ray_intersect(Index i, const Ray &ray, Float maxt) const override;
+        AABB get_triangle_aabb(Index i) const override;
+        Float get_triangle_area(Index i) const override;
+        std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const override;
 
         Index get_triangle_num() const override {
             return m_vertex_indices.size();
@@ -168,7 +174,10 @@ namespace Caramel{
         std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const override;
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const override;
 
-        Triangle get_triangle(Index i) const override;
+        std::pair<bool, RayIntersectInfo> get_triangle_ray_intersect(Index i, const Ray &ray, Float maxt) const override;
+        AABB get_triangle_aabb(Index i) const override;
+        Float get_triangle_area(Index i) const override;
+        std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const override;
 
         Index get_triangle_num() const override {
             return m_face_indices.size();

--- a/src/mesh_accel/naive.cpp
+++ b/src/mesh_accel/naive.cpp
@@ -46,7 +46,7 @@ namespace Caramel{
         bool is_hit = false;
 
         for (int i = 0; i < m_shape.get_triangle_num(); i++) {
-            auto [is_intersect, tmp_info] = m_shape.get_triangle(i).ray_intersect(ray, maxt);
+            auto [is_intersect, tmp_info] = m_shape.get_triangle_ray_intersect(i, ray, maxt);
             if (is_intersect) {
                 is_hit = true;
                 if (info.t > tmp_info.t) {

--- a/src/mesh_accel/octree.cpp
+++ b/src/mesh_accel/octree.cpp
@@ -48,9 +48,9 @@ namespace Caramel{
         }
 
         for(auto ti : m_triangle_indices){
-            const Triangle &tri = shape.get_triangle(ti);
+            const AABB tri_aabb = shape.get_triangle_aabb(ti);
             for(auto &child : m_childs){
-                if(child.m_aabb.is_contain(tri.get_center())){
+                if(child.m_aabb.is_contain(tri_aabb.get_center())){
                     child.m_triangle_indices.emplace_back(ti);
                     break;
                 }
@@ -62,9 +62,9 @@ namespace Caramel{
 
         // Shrink aabb as possible
         for (auto &child : m_childs) {
-            AABB shrinked_aabb = shape.get_triangle(child.m_triangle_indices[0]).get_aabb();
+            AABB shrinked_aabb = shape.get_triangle_aabb(child.m_triangle_indices[0]);
             for (const auto tri : child.m_triangle_indices) {
-                shrinked_aabb = AABB::merge(shrinked_aabb, shape.get_triangle(tri).get_aabb());
+                shrinked_aabb = AABB::merge(shrinked_aabb, shape.get_triangle_aabb(tri));
             }
             child.m_aabb = shrinked_aabb;
         }
@@ -96,7 +96,7 @@ namespace Caramel{
         info.t = maxt;
         bool is_hit = false;
         for(const Index i:m_triangle_indices){
-            const auto &[is_intersect, tmp_info] = shape.get_triangle(i).ray_intersect(ray, info.t);
+            const auto &[is_intersect, tmp_info] = shape.get_triangle_ray_intersect(i, ray, info.t);
             if (is_intersect) {
                 is_hit = true;
                 info = tmp_info;

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -124,7 +124,7 @@ namespace Caramel {
         m_area = Float0;
         // Initialize m_triangle_pdf used in sampling triangle.
         for(int i=0;i<m_vertex_indices.size();i++){
-            const Float ith_tri_area = get_triangle(i).get_area();
+            const Float ith_tri_area = get_triangle_area(i);
             triangle_area_vec[i] = ith_tri_area;
             m_area += ith_tri_area;
         }
@@ -155,7 +155,7 @@ namespace Caramel {
         const Index i = m_triangle_pdf.sample(sampler.sample_1d());
 
         // Sample point in chosen triangle
-        const auto [pos, normal, _] = get_triangle(i).sample_point(sampler);
+        const auto [pos, normal, _] = get_triangle_sample_point(i, sampler);
 
         return {pos, normal, Float1 / m_area};
     }
@@ -169,33 +169,98 @@ namespace Caramel {
         return dist_squared / (cos * m_area);
     }
 
-    Triangle OBJMesh::get_triangle(Index i) const {
-        if (is_vn_exists){
-            if(is_tx_exists){
-                return Triangle(m_vertices[m_vertex_indices[i][0]],
-                                m_vertices[m_vertex_indices[i][1]],
-                                m_vertices[m_vertex_indices[i][2]],
-                                m_normals[m_normal_indices[i][0]],
-                                m_normals[m_normal_indices[i][1]],
-                                m_normals[m_normal_indices[i][2]],
-                                m_tex_coords[m_tex_coord_indices[i][0]],
-                                m_tex_coords[m_tex_coord_indices[i][1]],
-                                m_tex_coords[m_tex_coord_indices[i][2]],
-                                get_bsdf());
-            }
-            return Triangle(m_vertices[m_vertex_indices[i][0]],
-                            m_vertices[m_vertex_indices[i][1]],
-                            m_vertices[m_vertex_indices[i][2]],
-                            m_normals[m_normal_indices[i][0]],
-                            m_normals[m_normal_indices[i][1]],
-                            m_normals[m_normal_indices[i][2]],
-                            get_bsdf());
+    Float OBJMesh::get_triangle_area(Index i) const {
+        const auto &v_idx = m_vertex_indices[i];
+        const Vector3f &p0 = m_vertices[v_idx[0]];
+        const Vector3f &p1 = m_vertices[v_idx[1]];
+        const Vector3f &p2 = m_vertices[v_idx[2]];
+
+        return Vector3f::cross(p1 - p0, p2 - p0).length() * Float0_5;
+    }
+
+    std::tuple<Vector3f, Vector3f, Float> OBJMesh::get_triangle_sample_point(Index i, Sampler &sampler) const {
+        const auto &v_idx = m_vertex_indices[i];
+        const Vector3f &p0 = m_vertices[v_idx[0]];
+        const Vector3f &p1 = m_vertices[v_idx[1]];
+        const Vector3f &p2 = m_vertices[v_idx[2]];
+
+        const Float u = sampler.sample_1d();
+        const Float v = sampler.sample_1d();
+        const Float x = Float1 - std::sqrt(Float1 - u);
+        const Float y = v * std::sqrt(Float1 - u);
+
+        Vector3f normal_vec;
+        if (is_vn_exists) {
+            const auto &n_idx = m_normal_indices[i];
+            const Vector3f &n0 = m_normals[n_idx[0]];
+            const Vector3f &n1 = m_normals[n_idx[1]];
+            const Vector3f &n2 = m_normals[n_idx[2]];
+            normal_vec = interpolate(n0, n1, n2, x, y).normalize();
+        } else {
+            normal_vec = Vector3f::cross(p1 - p0, p2 - p0).normalize();
         }
-        else{
-            return Triangle(m_vertices[m_vertex_indices[i][0]],
-                            m_vertices[m_vertex_indices[i][1]],
-                            m_vertices[m_vertex_indices[i][2]],
-                            get_bsdf());
+
+        return {interpolate(p0, p1, p2, x, y),
+                normal_vec,
+                Float1 / get_triangle_area(i)};
+    }
+
+    std::pair<bool, RayIntersectInfo> OBJMesh::get_triangle_ray_intersect(Index i, const Ray &ray, Float maxt) const {
+        const auto &v_idx = m_vertex_indices[i];
+        const Vector3f &p0 = m_vertices[v_idx[0]];
+        const Vector3f &p1 = m_vertices[v_idx[1]];
+        const Vector3f &p2 = m_vertices[v_idx[2]];
+
+        auto [u, v, t] = moller_trumbore(ray, p0, p1, p2, maxt);
+
+        if(u==-Float1 && v==-Float1 && t==-Float1){
+            return {false, RayIntersectInfo()};
         }
+
+        RayIntersectInfo ret;
+        ret.t = t;
+        
+        if (is_tx_exists) {
+            const auto &uv_idx = m_tex_coord_indices[i];
+            const Vector2f &uv0 = m_tex_coords[uv_idx[0]];
+            const Vector2f &uv1 = m_tex_coords[uv_idx[1]];
+            const Vector2f &uv2 = m_tex_coords[uv_idx[2]];
+            ret.tex_uv = interpolate(uv0, uv1, uv2, u, v);
+        } else {
+            ret.tex_uv = Vector2f{u, v};
+        }
+
+        ret.tex_uv[0] -= floor(ret.tex_uv[0]);
+        ret.tex_uv[1] -= floor(ret.tex_uv[1]);
+
+        ret.p = interpolate(p0, p1, p2, u, v);
+        
+        Vector3f n;
+        if (is_vn_exists) {
+            const auto &n_idx = m_normal_indices[i];
+            const Vector3f &n0 = m_normals[n_idx[0]];
+            const Vector3f &n1 = m_normals[n_idx[1]];
+            const Vector3f &n2 = m_normals[n_idx[2]];
+            n = interpolate(n0, n1, n2, u, v).normalize();
+        } else {
+            n = Vector3f::cross(p1 - p0, p2 - p0).normalize();
+        }
+        ret.sh_coord = Coordinate(n);
+
+        return {true, ret};
+    }
+
+    AABB OBJMesh::get_triangle_aabb(Index i) const {
+        const auto &v_idx = m_vertex_indices[i];
+        const Vector3f &p0 = m_vertices[v_idx[0]];
+        const Vector3f &p1 = m_vertices[v_idx[1]];
+        const Vector3f &p2 = m_vertices[v_idx[2]];
+        
+        return AABB(Vector3f{std::min({p0[0], p1[0], p2[0]}),
+                             std::min({p0[1], p1[1], p2[1]}),
+                             std::min({p0[2], p1[2], p2[2]})},
+                    Vector3f{std::max({p0[0], p1[0], p2[0]}),
+                             std::max({p0[1], p1[1], p2[1]}),
+                             std::max({p0[2], p1[2], p2[2]})});
     }
 }


### PR DESCRIPTION
before

<img width="496" height="381" alt="before" src="https://github.com/user-attachments/assets/09787ed1-be09-43f8-abd2-60f8dc9f9539" />

after

<img width="539" height="368" alt="after" src="https://github.com/user-attachments/assets/fb800b7b-e062-457a-822a-96b0eccfbebf" />

