### PR TITLE
Fix `Scene::is_visible()`

### DIFF
--- a/include/light.h
+++ b/include/light.h
@@ -42,9 +42,9 @@ namespace Caramel{
 
         // Sample a point on the light from given pos
         // returns emitted radiance, sampled point on the light, normal at the sampled point, and its pdf
-        virtual std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> sample_direct_contribution(const Scene &scene,
-                                                                                                             const RayIntersectInfo &hitpos_info,
-                                                                                                             Sampler &sampler) const = 0;
+        virtual std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
+                                                                                           const RayIntersectInfo &hitpos_info,
+                                                                                           Sampler &sampler) const = 0;
 
         // Probability of hitpos_world sampled from hitpos_world respect to solid angle
         // This function should not be used from delta lights since they don't have to be sampled
@@ -70,9 +70,9 @@ namespace Caramel{
         ~PointLight();
 
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> sample_direct_contribution(const Scene &scene,
-                                                                                                     const RayIntersectInfo &hitpos_info,
-                                                                                                     Sampler &) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
+                                                                                   const RayIntersectInfo &hitpos_info,
+                                                                                   Sampler &) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -89,9 +89,9 @@ namespace Caramel{
         ~AreaLight();
         
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> sample_direct_contribution(const Scene &scene,
-                                                                                                     const RayIntersectInfo &hitpos_info,
-                                                                                                     Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
+                                                                                   const RayIntersectInfo &hitpos_info,
+                                                                                   Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -112,9 +112,9 @@ namespace Caramel{
         ConstantEnvLight(const Vector3f &radiance, Float scale);
 
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> sample_direct_contribution(const Scene &scene,
-                                                                                                     const RayIntersectInfo &hitpos_info,
-                                                                                                     Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
+                                                                                   const RayIntersectInfo &hitpos_info,
+                                                                                   Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -130,9 +130,9 @@ namespace Caramel{
         ImageEnvLight(const std::string &path, Float scale);
 
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> sample_direct_contribution(const Scene &scene,
-                                                                                                     const RayIntersectInfo &hitpos_info,
-                                                                                                     Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
+                                                                                   const RayIntersectInfo &hitpos_info,
+                                                                                   Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 

--- a/include/scene.h
+++ b/include/scene.h
@@ -48,7 +48,7 @@ namespace Caramel{
         std::pair<bool, RayIntersectInfo> ray_intersect(const Ray &ray, Float maxt=INF) const;
         void add_mesh_and_arealight(const Shape *shape);
         void add_light(Light *light);
-        std::pair<bool, RayIntersectInfo> is_visible(const Vector3f &pos1, const Vector3f &pos2) const;
+        bool is_visible(const Vector3f &pos1, const Vector3f &pos2) const;
         std::pair<const Light*, Float> sample_light(Sampler &sampler) const;
         void build_bvh();
 

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -88,7 +88,7 @@ namespace Caramel{
             if(!is_current_specular){
                 auto [light, light_pick_pdf] = scene.sample_light(sampler);
 
-                auto [emitted_rad, light_pos, light_n_world, light_pos_pdf, light_info] = light->sample_direct_contribution(scene, info, sampler);
+                auto [emitted_rad, light_pos, light_n_world, light_pos_pdf] = light->sample_direct_contribution(scene, info, sampler);
 
                 // Continue if light sampling succeed
                 if(!is_zero(emitted_rad)){
@@ -102,7 +102,7 @@ namespace Caramel{
                         }
                         else{
                             // MIS for light sampling
-                            const Float pdf_solidangle = light->pdf_solidangle(info.p, light_pos, light_info.sh_coord.m_world_n);
+                            const Float pdf_solidangle = light->pdf_solidangle(info.p, light_pos, light_n_world);
                             const Float bsdf_pdf = shape->get_bsdf()->pdf(local_ray_dir, hitpos_to_light_local_normal);
                             const Float light_pdf = light_pick_pdf * pdf_solidangle;
                             ret = ret + (fr % emitted_rad % current_brdf) * std::abs(hitpos_to_light_local_normal[2]) * balance_heuristic(light_pdf, bsdf_pdf) / light_pdf;

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -46,23 +46,23 @@ namespace Caramel{
         return m_radiance;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> AreaLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f, Float> AreaLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         // Sample point on the shape
         const auto [light_pos, light_normal_world, pos_pdf] = m_shape->sample_point(sampler);
         const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
 
         // If hitpoint is behind of a sampled point, zero contribution
         if(light_normal_world.dot(light_to_hitpos) <= 0){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf, RayIntersectInfo()};
+            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
         }
 
         // If hitpoint and sampled point is not visible to each other, zero contribution
-        auto [is_visible, info] = scene.is_visible(hitpos_info.p, light_pos);
+        bool is_visible = scene.is_visible(hitpos_info.p, light_pos);
         if(!is_visible){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf, RayIntersectInfo()};
+            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
         }
 
-        return {m_radiance, light_pos, light_normal_world, pos_pdf, info};
+        return {m_radiance, light_pos, light_normal_world, pos_pdf};
     }
 
     Float AreaLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{

--- a/src/lights/constantEnvLight.cpp
+++ b/src/lights/constantEnvLight.cpp
@@ -44,17 +44,17 @@ namespace Caramel{
         return m_radiance;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> ConstantEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f, Float> ConstantEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         const auto [pos_to_light_dir_local, pos_pdf] = sample_unit_sphere_uniformly(sampler);
         const auto pos_to_light_dir_world = hitpos_info.sh_coord.to_world(pos_to_light_dir_local);
 
         const Vector3f light_pos = hitpos_info.p + (pos_to_light_dir_world * scene.m_sceneRadius * 2);
-        auto [visible, info] = scene.is_visible(light_pos, hitpos_info.p);
+        bool visible = scene.is_visible(light_pos, hitpos_info.p);
         if (!visible) {
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf, RayIntersectInfo()};
+            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
         }
 
-        return {m_radiance, light_pos, -pos_to_light_dir_world, PI_4_INV, RayIntersectInfo()/*TODO?*/};
+        return {m_radiance, light_pos, -pos_to_light_dir_world, PI_4_INV};
     }
 
     Float ConstantEnvLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{

--- a/src/lights/imageEnvLight.cpp
+++ b/src/lights/imageEnvLight.cpp
@@ -51,7 +51,7 @@ namespace Caramel{
         return m_image->get_pixel_value(uv[0] * size[0], uv[1] * size[1]);
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> ImageEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f, Float> ImageEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         const auto sampled_uv = m_imageDistrib.sample(sampler.sample_1d(), sampler.sample_1d());
         const auto pos_to_light_world = normalized_uv_to_vec(Vector2f{static_cast<Float>(sampled_uv[0] + Float0_5) / m_width, static_cast<Float>(sampled_uv[1] + Float0_5) / m_height});
 
@@ -72,12 +72,12 @@ namespace Caramel{
         //
         const auto pdf = m_width_height * m_imageDistrib.pdf/*technically it's pmf*/(sampled_uv[0], sampled_uv[1]) / (2 * PI * PI * std::sin(static_cast<Float>((sampled_uv[1] + Float0_5) / m_height) * PI));
 
-        auto [visible, info] = scene.is_visible(light_pos, hitpos_info.p);
+        bool visible = scene.is_visible(light_pos, hitpos_info.p);
         if (!visible) {
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pdf, RayIntersectInfo()};
+            return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
         }
 
-        return {radiance(hitpos_info.p, light_pos, -pos_to_light_world), light_pos, -pos_to_light_world, pdf, RayIntersectInfo()/*TODO?*/};
+        return {radiance(hitpos_info.p, light_pos, -pos_to_light_world), light_pos, -pos_to_light_world, pdf};
     }
 
     Float ImageEnvLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{

--- a/src/lights/point.cpp
+++ b/src/lights/point.cpp
@@ -43,18 +43,18 @@ namespace Caramel{
         return vec3f_zero;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float, RayIntersectInfo> PointLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &) const{
+    std::tuple<Vector3f, Vector3f, Vector3f, Float> PointLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &) const{
         // If hitpoint and sampled point is not visible to each other, zero contribution
-        auto [is_visible, info] = scene.is_visible(m_pos, hitpos_info.p);
+        bool is_visible = scene.is_visible(m_pos, hitpos_info.p);
 
         if(!is_visible){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, Float1, RayIntersectInfo()};
+            return {vec3f_zero, vec3f_zero, vec3f_zero, Float1};
         }
 
         const Vector3f light_to_hitpos = hitpos_info.p - m_pos;
         const Float dist = light_to_hitpos.length();
 
-        return {m_radiance / (dist * dist), m_pos, light_to_hitpos.normalize(), Float1, info};
+        return {m_radiance / (dist * dist), m_pos, light_to_hitpos.normalize(), Float1};
     }
 
     Float PointLight::pdf_solidangle(const Vector3f &, const Vector3f &, const Vector3f &) const{

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -69,19 +69,14 @@ namespace Caramel{
     }
 
     // Similar with `RayIntersectInfo::recursive_ray_to()`
-    std::pair<bool, RayIntersectInfo> Scene::is_visible(const Vector3f &pos1, const Vector3f &pos2) const{
+    bool Scene::is_visible(const Vector3f &pos1, const Vector3f &pos2) const{
         const Vector3f vec3_1_to_2(pos2 - pos1);
         const Vector3f dir = vec3_1_to_2.normalize();
         const Float len = vec3_1_to_2.length();
         const Ray ray{pos1 + (dir * EPSILON), dir};
 
         const auto [is_hit, info] = ray_intersect(ray, len);
-
-        if(!is_hit){
-            return {false, RayIntersectInfo()};
-        }
-
-        return {std::abs(len - info.t) <= (EPSILON * static_cast<Float>(1.1)), info};
+        return !is_hit || std::abs(len - info.t) <= (EPSILON * static_cast<Float>(1.1));
     }
 
     std::pair<const Light*, Float> Scene::sample_light(Sampler &sampler) const{

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -1720,7 +1720,7 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         Vector3f obs_pos{0.0f, 0.0f, 1.0f}; // In front of target
         Vector3f target_pos{0.0f, 0.0f, 0.0f}; // On target (centroid)
 
-        auto [visible, info] = scene.is_visible(obs_pos, target_pos);
+        bool visible = scene.is_visible(obs_pos, target_pos);
         CHECK(visible == true);
     }
 
@@ -1728,7 +1728,7 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         Vector3f obs_pos{0.0f, 0.0f, 4.0f}; // Behind occluder (Z=2)
         Vector3f target_pos{0.0f, 0.0f, 0.0f}; // On target (Z=0)
         
-        auto [visible, info] = scene.is_visible(obs_pos, target_pos);
+        bool visible = scene.is_visible(obs_pos, target_pos);
         CHECK(visible == false);
     }
 
@@ -1736,7 +1736,7 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         Vector3f obs_pos{0.0f, 0.0f, 4.0f};
         Vector3f target_pos{10.0f, 10.0f, 0.0f}; // Way outside
         
-        auto [visible, info] = scene.is_visible(obs_pos, target_pos);
+        bool visible = scene.is_visible(obs_pos, target_pos);
         CHECK(visible == false);
     }
 
@@ -1746,11 +1746,11 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         // 1. Just outside epsilon (should be visible)
         // Epsilon is 1e-3. Let's try 2e-3.
         Vector3f obs_safe{0.0f, 0.0f, 0.002f};
-        CHECK(scene.is_visible(obs_safe, target_pos).first == true);
+        CHECK(scene.is_visible(obs_safe, target_pos) == true);
 
         // 2. Inside epsilon (ray starts behind target, so it misses)
         Vector3f obs_unsafe{0.0f, 0.0f, 0.0005f};
-        CHECK(scene.is_visible(obs_unsafe, target_pos).first == false);
+        CHECK(scene.is_visible(obs_unsafe, target_pos) == false);
     }
     
     SECTION("Robustness - Grazing angle") {
@@ -1758,7 +1758,7 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         // Ray travels almost parallel to Z=0 plane.
         Vector3f obs_pos{10.0f, 0.0f, 0.1f};
         Vector3f target_pos{0.0f, 0.0f, 0.0f};
-        CHECK(scene.is_visible(obs_pos, target_pos).first == true);
+        CHECK(scene.is_visible(obs_pos, target_pos) == true);
     }
 
     SECTION("Robustness - Very close to Occluder") {
@@ -1768,12 +1768,12 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         // 1. Observer just BEFORE occluder (should be blocked)
         // Z=2.002. Ray origin starts at 2.001. Hits Z=2.0.
         Vector3f obs_blocked{0.0f, 0.0f, 2.002f};
-        CHECK(scene.is_visible(obs_blocked, target_pos).first == false);
+        CHECK(scene.is_visible(obs_blocked, target_pos) == false);
 
         // 2. Observer inside occluder epsilon (should see through)
         // Z=2.0005. Ray origin starts at 1.9995 (past occluder).
         Vector3f obs_past{0.0f, 0.0f, 2.0005f};
-        CHECK(scene.is_visible(obs_past, target_pos).first == true);
+        CHECK(scene.is_visible(obs_past, target_pos) == true);
     }
 
     delete tri1;

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -1732,12 +1732,12 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
         CHECK(visible == false);
     }
 
-    SECTION("Miss - Target is empty space") {
+    SECTION("Visible - Target is empty space") {
         Vector3f obs_pos{0.0f, 0.0f, 4.0f};
         Vector3f target_pos{10.0f, 10.0f, 0.0f}; // Way outside
         
         bool visible = scene.is_visible(obs_pos, target_pos);
-        CHECK(visible == false);
+        CHECK(visible == true);
     }
 
     SECTION("Robustness - Very close to target") {
@@ -1750,11 +1750,10 @@ TEST_CASE("Scene::is_visible", "[UnitTest]") {
 
         // 2. Inside epsilon (ray starts behind target, so it misses)
         Vector3f obs_unsafe{0.0f, 0.0f, 0.0005f};
-        CHECK(scene.is_visible(obs_unsafe, target_pos) == false);
+        CHECK(scene.is_visible(obs_unsafe, target_pos) == true);
     }
-    
-    SECTION("Robustness - Grazing angle") {
-        // Observer at (10, 0, 0.1). Target at (0, 0, 0).
+        
+            SECTION("Robustness - Grazing angle") {        // Observer at (10, 0, 0.1). Target at (0, 0, 0).
         // Ray travels almost parallel to Z=0 plane.
         Vector3f obs_pos{10.0f, 0.0f, 0.1f};
         Vector3f target_pos{0.0f, 0.0f, 0.0f};


### PR DESCRIPTION
1. We don't have to return unnecessary `RayIntersectInfo`
2. We can treat as visible if there is no occlusion