### PR TITLE
Add solid angle sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ if(NOT EXCLUDE_TEST)
             test/simple_render_test.cpp
             test/unit_tests.cpp
             test/chi2_bsdf_test.cpp
+            test/chi2_polygon_test.cpp
             test/utils.cpp
     )
 

--- a/include/light.h
+++ b/include/light.h
@@ -113,12 +113,9 @@ namespace Caramel{
             return new AreaLight(args...);
         }
 
-        void init_is_triangle_mesh();
-
         Shape *m_shape;
         Vector3f m_radiance;
-        bool m_is_triangle_mesh = false;
-        static constexpr bool SOLID_ANGLE_SAMPLING = true;
+        static constexpr bool TRY_SOLID_ANGLE_SAMPLING = true;
     };
 
     class ConstantEnvLight final : public Light {

--- a/include/light.h
+++ b/include/light.h
@@ -41,10 +41,10 @@ namespace Caramel{
         Light() {}
 
         // Sample a point on the light from given pos
-        // returns emitted radiance, sampled point on the light, normal at the sampled point, and its pdf
-        virtual std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
-                                                                                           const RayIntersectInfo &hitpos_info,
-                                                                                           Sampler &sampler) const = 0;
+        // returns emitted radiance, sampled point on the light, normal at the sampled point
+        virtual std::tuple<Vector3f, Vector3f, Vector3f> sample_direct_contribution(const Scene &scene,
+                                                                                    const RayIntersectInfo &hitpos_info,
+                                                                                    Sampler &sampler) const = 0;
 
         // Probability of hitpos_world sampled from hitpos_world respect to solid angle
         // This function should not be used from delta lights since they don't have to be sampled
@@ -76,9 +76,9 @@ namespace Caramel{
 
         Float power() const override;
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
-                                                                                   const RayIntersectInfo &hitpos_info,
-                                                                                   Sampler &) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> sample_direct_contribution(const Scene &scene,
+                                                                            const RayIntersectInfo &hitpos_info,
+                                                                            Sampler &) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -99,9 +99,9 @@ namespace Caramel{
         
         Float power() const override;
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
-                                                                                   const RayIntersectInfo &hitpos_info,
-                                                                                   Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> sample_direct_contribution(const Scene &scene,
+                                                                            const RayIntersectInfo &hitpos_info,
+                                                                            Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -124,9 +124,9 @@ namespace Caramel{
 
         Float power() const override;
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
-                                                                                   const RayIntersectInfo &hitpos_info,
-                                                                                   Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> sample_direct_contribution(const Scene &scene,
+                                                                            const RayIntersectInfo &hitpos_info,
+                                                                            Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 
@@ -146,9 +146,9 @@ namespace Caramel{
 
         Float power() const override;
         Vector3f radiance(const Vector3f &hitpos, const Vector3f &lightpos, const Vector3f &light_normal_world) const override;
-        std::tuple<Vector3f, Vector3f, Vector3f, Float> sample_direct_contribution(const Scene &scene,
-                                                                                   const RayIntersectInfo &hitpos_info,
-                                                                                   Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> sample_direct_contribution(const Scene &scene,
+                                                                            const RayIntersectInfo &hitpos_info,
+                                                                            Sampler &sampler) const override;
 
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const override;
 

--- a/include/light.h
+++ b/include/light.h
@@ -113,8 +113,12 @@ namespace Caramel{
             return new AreaLight(args...);
         }
 
+        void init_is_triangle_mesh();
+
         Shape *m_shape;
         Vector3f m_radiance;
+        bool m_is_triangle_mesh = false;
+        static constexpr bool SOLID_ANGLE_SAMPLING = true;
     };
 
     class ConstantEnvLight final : public Light {

--- a/include/polygon_sampling.h
+++ b/include/polygon_sampling.h
@@ -84,7 +84,7 @@ namespace Caramel{
     // to get the correct angle for the Van Oosterom-Strackee formula.
     inline Float positive_atan(Float tangent) {
         using std::atan;
-        return atan(tangent) + (tangent < Float0) ? PI : Float0;
+        return atan(tangent) + ((tangent < Float0) ? PI : Float0);
     }
 
     // Numerically stable linear interpolation: x*(1-a) + y*a

--- a/include/polygon_sampling.h
+++ b/include/polygon_sampling.h
@@ -1,0 +1,277 @@
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2022-2025 Jino Park
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+// Solid angle sampling of convex polygons.
+// Based on: Christoph Peters, 2021
+//   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
+//   https://doi.org/10.1145/3450626.3459672
+//
+// Given a convex polygon light and a shading point, this samples a direction
+// uniformly distributed over the solid angle subtended by the polygon.
+// The PDF is simply 1 / solid_angle (uniform in solid angle measure).
+//
+// The sampled result is a unit direction vector from the shading point toward
+// the polygon. To recover the actual 3D point on the light surface, a ray-plane
+// intersection is needed:
+//
+//   plane_n = cross(p1 - p0, p2 - p0)        // unnormalized triangle normal
+//   t = dot(plane_n, p0 - origin) / dot(plane_n, dir)
+//   light_pos = origin + t * dir
+//
+// This is necessary because the algorithm operates entirely on the unit sphere
+// (spherical polygon), so it only produces directions, not positions.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+
+#include <common.h>
+
+namespace Caramel{
+
+    constexpr Index MAX_POLYGON_VERTEX_COUNT = 8;
+
+    // Precomputed data for a convex polygon projected onto the unit sphere.
+    // Used by sample_solid_angle_polygon() to sample directions.
+    struct SolidAnglePolygon {
+        // Number of vertices of the polygon
+        Index vertex_count;
+
+        // Normalized direction vectors from the shading point to each vertex.
+        // These are the polygon vertices projected onto the unit sphere.
+        std::array<Vector3f, MAX_POLYGON_VERTEX_COUNT> vertex_dirs;
+
+        // Precomputed parameters for each triangle in the fan triangulation.
+        // For the i-th triangle (vertex_dirs[i+1], vertex_dirs[0], vertex_dirs[i+2]):
+        //   [0] = |det(v0, v1, v2)| computed via Householder reflection (simplex volume)
+        //   [1] = dot(v0, v2) + dot(v1, v2)
+        //   [2] = 1 + dot(v0, v1)
+        // These are used in the Van Oosterom-Strackee formula and sampling.
+        std::array<Vector3f, MAX_POLYGON_VERTEX_COUNT - 2> triangle_parameters;
+
+        // Cumulative solid angles of the fan triangles.
+        // fan_solid_angles[i] = sum of solid angles of triangles 0..i
+        std::array<Float, MAX_POLYGON_VERTEX_COUNT - 2> fan_solid_angles;
+
+        // Total solid angle subtended by the polygon as seen from the shading point
+        Float solid_angle;
+    };
+
+    // Compute atan(tangent) mapped to [0, pi).
+    // Standard atan returns [-pi/2, pi/2], so we add pi when tangent < 0
+    // to get the correct angle for the Van Oosterom-Strackee formula.
+    inline Float positive_atan(Float tangent) {
+        using std::atan;
+        return atan(tangent) + (tangent < Float0) ? PI : Float0;
+    }
+
+    // Numerically stable linear interpolation: x*(1-a) + y*a
+    // Uses two fma (fused multiply-add) operations to minimize rounding error:
+    //   fma(-a, x, x) = x - a*x = x*(1-a)
+    //   fma(a, y, ...)  adds a*y
+    inline Float mix_fma(Float x, Float y, Float a) {
+        using std::fma;
+        return fma(a, y, fma(-a, x, x));
+    }
+
+    // Precompute the solid angle polygon data for a convex polygon.
+    //
+    // The polygon is decomposed into a fan of spherical triangles sharing vertex_dirs[0].
+    // For each triangle, we compute:
+    //   - The solid angle via the Van Oosterom-Strackee formula:
+    //       tan(Omega/2) = |det(v0,v1,v2)| / (1 + d01 + d02 + d12)
+    //     where dij = dot(vi, vj) and vi are unit vectors from the shading point.
+    //   - The |det| is computed using a Householder reflection that maps vertex_dirs[0]
+    //     onto the x-axis, reducing the 3x3 determinant to a 2x2 determinant for
+    //     better numerical stability (avoids catastrophic cancellation).
+    //
+    // Parameters:
+    //   vertex_count: number of polygon vertices (3 to MAX_POLYGON_VERTEX_COUNT)
+    //   vertices:     world-space vertex positions of the convex polygon
+    //   shading_pos:  world-space position of the shading point
+    inline SolidAnglePolygon prepare_solid_angle_polygon(Index vertex_count, const Vector3f* vertices, const Vector3f& shading_pos) {
+        using std::abs;
+        using std::fma;
+
+        SolidAnglePolygon polygon;
+        polygon.vertex_count = vertex_count;
+
+        // Project each vertex onto the unit sphere centered at the shading point
+        for (Index i = 0; i < vertex_count; ++i) {
+            const Vector3f diff = vertices[i] - shading_pos;
+            polygon.vertex_dirs[i] = diff.normalize();
+        }
+
+        // Householder reflection setup: map vertex_dirs[0] onto (+-1, 0, 0).
+        // The reflection vector h = vertex_dirs[0] - sign * e_x, and we precompute
+        // only the yz-components with the 2/||h||^2 scaling baked in.
+        // This avoids explicitly forming the full Householder matrix.
+        const Float householder_sign = (polygon.vertex_dirs[0][0] > Float0) ? -Float1 : Float1;
+        const Float hh_denom = Float1 / (abs(polygon.vertex_dirs[0][0]) + Float1);
+        const Vector2f householder_yz{polygon.vertex_dirs[0][1] * hh_denom,
+                                      polygon.vertex_dirs[0][2] * hh_denom};
+
+        polygon.solid_angle = Float0;
+
+        // Cache dot product between vertex_dirs[0] and vertex_dirs[1] for reuse
+        Float previous_dot_1_2 = polygon.vertex_dirs[0].dot(polygon.vertex_dirs[1]);
+
+        // Iterate over fan triangles: (vertex_dirs[i+1], vertex_dirs[0], vertex_dirs[i+2])
+        for (Index i = 0; i + 2 < vertex_count; ++i) {
+            const Vector3f& v0 = polygon.vertex_dirs[i + 1];  // current edge start
+            const Vector3f& v1 = polygon.vertex_dirs[0];       // fan center (shared vertex)
+            const Vector3f& v2 = polygon.vertex_dirs[i + 2];   // current edge end
+
+            // Dot products between all pairs of the triangle vertices
+            const Float dot_01 = previous_dot_1_2;   // reuse from previous iteration
+            const Float dot_02 = v0.dot(v2);
+            const Float dot_12 = v1.dot(v2);
+            previous_dot_1_2 = dot_12;  // cache for next iteration
+
+            // Apply Householder reflection to compute |det(v0, v1, v2)| stably.
+            // After reflection, v1 maps to (+-1, 0, 0), so the 3x3 determinant
+            // reduces to a 2x2 determinant of the yz-components of Hv0 and Hv2.
+            //
+            // dot_hh_0 = dot(H*v0, H*v1) projected term = dot(v0, v1) - sign * v0.x
+            const Float dot_hh_0 = fma(-householder_sign, v0[0], dot_01);
+            const Float dot_hh_2 = fma(-householder_sign, v2[0], dot_12);
+
+            // yz-components of Householder-transformed v0 and v2:
+            //   (Hv)_yz = v_yz - dot_hh * householder_yz
+            const Float col0_y = fma(-dot_hh_0, householder_yz[0], v0[1]);
+            const Float col0_z = fma(-dot_hh_0, householder_yz[1], v0[2]);
+            const Float col1_y = fma(-dot_hh_2, householder_yz[0], v2[1]);
+            const Float col1_z = fma(-dot_hh_2, householder_yz[1], v2[2]);
+
+            // 2x2 determinant = |det(v0, v1, v2)| = simplex volume
+            const Float simplex_volume = abs(col0_y * col1_z - col0_z * col1_y);
+
+            // Van Oosterom-Strackee formula for the solid angle of a spherical triangle:
+            //   tan(Omega/2) = |det(v0, v1, v2)| / (1 + d01 + d02 + d12)
+            //   Omega = 2 * atan(tan(Omega/2))
+            // We store intermediate terms for reuse during sampling.
+            const Float dot_02_plus_12 = dot_02 + dot_12;
+            const Float one_plus_dot_01 = Float1 + dot_01;
+            const Float tangent = simplex_volume / (one_plus_dot_01 + dot_02_plus_12);
+            const Float triangle_solid_angle = Float2 * positive_atan(tangent);
+
+            // Accumulate the cumulative solid angle for triangle selection during sampling
+            polygon.solid_angle += triangle_solid_angle;
+            polygon.fan_solid_angles[i] = polygon.solid_angle;
+
+            // Store (simplex_volume, dot_02+dot_12, 1+dot_01) for use in sampling
+            polygon.triangle_parameters[i] = Vector3f{simplex_volume, dot_02_plus_12, one_plus_dot_01};
+        }
+
+        return polygon;
+    }
+
+    // Sample a unit direction uniformly distributed over the solid angle of the polygon.
+    //
+    // Algorithm (Peters, Section 5):
+    //   1. Use u0 to select a fan triangle proportional to its solid angle,
+    //      and compute the residual solid angle within that triangle.
+    //   2. Construct a new vertex L2' on the great arc (v0, v2) such that the
+    //      sub-triangle (v0, v1, L2') has the desired sub-solid-angle.
+    //      This uses the shortcut formula (Supplement C.3):
+    //        offset = (P0*cos(h) - P1*sin(h)) * v0 + P2*sin(h) * v2
+    //        L2' = -v0 + 2 * dot(v0, offset) / dot(offset, offset) * offset
+    //      which is a reflection of v0 through the plane defined by offset.
+    //   3. Use u1 to linearly interpolate along the great arc (v1, L2') via slerp.
+    //
+    // Parameters:
+    //   polygon: precomputed polygon data from prepare_solid_angle_polygon()
+    //   u0, u1:  uniform random numbers in [0, 1)
+    //
+    // Returns:
+    //   A unit direction vector from the shading point toward the sampled point
+    //   on the polygon. This direction lies within the solid angle of the polygon.
+    inline Vector3f sample_solid_angle_polygon(const SolidAnglePolygon& polygon, Float u0, Float u1) {
+        using std::cos;
+        using std::sin;
+        using std::sqrt;
+        using std::fma;
+
+        // Step 1: Select which fan triangle to sample from.
+        // Scale u0 by total solid angle to get a target cumulative solid angle.
+        const Float target_solid_angle = polygon.solid_angle * u0;
+
+        // Start with the first triangle's data as default
+        Float subtriangle_solid_angle = target_solid_angle;
+        Vector3f parameters = polygon.triangle_parameters[0];
+        Vector3f v0 = polygon.vertex_dirs[1];   // fan triangle edge start
+        Vector3f v1 = polygon.vertex_dirs[0];   // fan center (shared vertex)
+        Vector3f v2 = polygon.vertex_dirs[2];   // fan triangle edge end
+
+        // Walk the cumulative solid angle array to find the right triangle
+        for (Index i = 0; i + 3 < polygon.vertex_count; ++i) {
+            if (polygon.fan_solid_angles[i] >= target_solid_angle) break;
+
+            // Subtract the cumulative angle to get the residual within the next triangle
+            subtriangle_solid_angle = target_solid_angle - polygon.fan_solid_angles[i];
+            v0 = polygon.vertex_dirs[i + 2];
+            v2 = polygon.vertex_dirs[i + 3];
+            parameters = polygon.triangle_parameters[i + 1];
+        }
+
+        // Step 2: Construct new vertex L2' on the arc v0-v2.
+        // half_angle = half of the residual solid angle we want the sub-triangle to have
+        const Float half_angle = Float0_5 * subtriangle_solid_angle;
+        const Float cos_half = cos(half_angle);
+        const Float sin_half = sin(half_angle);
+
+        // Peters' shortcut formula (Supplement C.3):
+        //   offset = (P0*cos - P1*sin) * v0 + P2*sin * v2
+        // where P0 = simplex_volume, P1 = dot_02+dot_12, P2 = 1+dot_01
+        const Float coeff_v0 = parameters[0] * cos_half - parameters[1] * sin_half;
+        const Float coeff_v2 = parameters[2] * sin_half;
+        const Vector3f offset = v0 * coeff_v0 + v2 * coeff_v2;
+
+        // Reflect v0 through the plane containing the origin with normal perpendicular to offset:
+        //   L2' = -v0 + 2 * dot(v0, offset) / dot(offset, offset) * offset
+        // This places L2' on the great arc from v0 to v2 at the correct solid angle.
+        const Float scale = Float2 * v0.dot(offset) / offset.dot(offset);
+        const Vector3f new_vertex_2 = offset * scale - v0;
+
+        // Step 3: Sample along the great arc from v1 to new_vertex_2 using u1.
+        // This is an efficient slerp parameterization.
+        //   s2 = cos(angle between v1 and L2')
+        //   s  = lerp(1, s2, u1) = cos of the interpolated angle
+        //   t_normed = sin of the interpolated angle / sin of the full angle
+        const Float s2 = v1.dot(new_vertex_2);
+        const Float s = mix_fma(Float1, s2, u1);
+        const Float denominator = fma(-s2, s2, Float1);   // = 1 - s2^2 = sin^2(angle)
+        Float t_normed = sqrt(fma(-s, s, Float1) / denominator);
+
+        // Fallback for degenerate case: when v1 and new_vertex_2 are nearly identical
+        // (s2 -> 1), denominator -> 0, so we fall back to linear interpolation
+        t_normed = (denominator > Float0) ? t_normed : u1;
+
+        // Final sampled direction = slerp(v1, new_vertex_2, u1)
+        //   = v1 * (s - t_normed * s2) + new_vertex_2 * t_normed
+        return v1 * fma(-t_normed, s2, s) + new_vertex_2 * t_normed;
+    }
+
+}

--- a/include/rayintersectinfo.h
+++ b/include/rayintersectinfo.h
@@ -41,5 +41,6 @@ namespace Caramel{
         Float t;      // Length of the ray from origin to hitpoint
         const Shape *shape;    // Shape index in a scene
         Vector2f tex_uv; // Texture coordinate
+        Index tri_index{0}; // Triangle index within mesh (used by TriangleMesh)
     };
 }

--- a/include/shape.h
+++ b/include/shape.h
@@ -43,8 +43,6 @@ namespace Caramel{
     class Distrib1D;
     class MeshAccel;
 
-    enum class SolidAngleSamplingType { SinglePolygon, PerTriangle, Impossible };
-
     class Shape{
     public:
         Shape(BSDF *bsdf, AreaLight *arealight);
@@ -59,8 +57,7 @@ namespace Caramel{
         // Probability to sample shapepos_world at hitpos_world respect to solid angle
         virtual Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const = 0;
 
-        virtual SolidAngleSamplingType get_solid_angle_sampling_type() const = 0;
-        virtual Index get_polygon_vertex_count() const = 0;
+        virtual bool is_solid_angle_sampling_possible() const = 0;
         virtual const std::vector<Vector3f>& get_polygon_vertices() const = 0;
 
         Vector3f get_center() const;
@@ -107,8 +104,7 @@ namespace Caramel{
         std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const override;
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const override;
 
-        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
-        Index get_polygon_vertex_count() const override;
+        bool is_solid_angle_sampling_possible() const override;
         const std::vector<Vector3f>& get_polygon_vertices() const override;
 
         Vector3f point(Index i) const{
@@ -164,8 +160,7 @@ namespace Caramel{
             return m_vertex_indices.size();
         }
 
-        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
-        Index get_polygon_vertex_count() const override;
+        bool is_solid_angle_sampling_possible() const override;
         const std::vector<Vector3f>& get_polygon_vertices() const override;
 
     private:
@@ -182,9 +177,9 @@ namespace Caramel{
         std::vector<Vector3i> m_normal_indices;
         std::vector<Vector3i> m_tex_coord_indices;
 
+        // for solid angle sampling
         std::vector<Vector3f> m_polygon_vertices;
-        Index m_polygon_vertex_count = 0;
-        SolidAngleSamplingType m_sampling_type = SolidAngleSamplingType::Impossible;
+        bool m_is_solid_angle_sampling_possible = false;
     };
 
     class PLYMesh final : public TriangleMesh{
@@ -210,8 +205,7 @@ namespace Caramel{
             return m_face_indices.size();
         }
 
-        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
-        Index get_polygon_vertex_count() const override;
+        bool is_solid_angle_sampling_possible() const override;
         const std::vector<Vector3f>& get_polygon_vertices() const override;
 
     private:
@@ -224,9 +218,9 @@ namespace Caramel{
         std::vector<Vector3f> m_normals;
         std::vector<Vector3i> m_face_indices;
 
+        // for solid angle sampling
         std::vector<Vector3f> m_polygon_vertices;
-        Index m_polygon_vertex_count = 0;
-        SolidAngleSamplingType m_sampling_type = SolidAngleSamplingType::Impossible;
+        bool m_is_solid_angle_sampling_possible = false;
     };
 
     // u, v, t

--- a/include/shape.h
+++ b/include/shape.h
@@ -43,6 +43,8 @@ namespace Caramel{
     class Distrib1D;
     class MeshAccel;
 
+    enum class SolidAngleSamplingType { SinglePolygon, PerTriangle, Impossible };
+
     class Shape{
     public:
         Shape(BSDF *bsdf, AreaLight *arealight);
@@ -56,6 +58,10 @@ namespace Caramel{
         virtual std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const = 0;
         // Probability to sample shapepos_world at hitpos_world respect to solid angle
         virtual Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const = 0;
+
+        virtual SolidAngleSamplingType get_solid_angle_sampling_type() const = 0;
+        virtual Index get_polygon_vertex_count() const = 0;
+        virtual const std::vector<Vector3f>& get_polygon_vertices() const = 0;
 
         Vector3f get_center() const;
 
@@ -101,17 +107,21 @@ namespace Caramel{
         std::tuple<Vector3f, Vector3f, Float> sample_point(Sampler &sampler) const override;
         Float pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &shapepos_world, const Vector3f &shape_normal_world) const override;
 
+        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
+        Index get_polygon_vertex_count() const override;
+        const std::vector<Vector3f>& get_polygon_vertices() const override;
+
         Vector3f point(Index i) const{
-            return i == 0 ? m_p0 : i == 1 ? m_p1 : m_p2;
+            return m_points[i];
         }
 
         Vector3f normal(Index i) const{
-            return i == 0 ? m_n0 : i == 1 ? m_n1 : m_n2;
+            return m_normals[i];
         }
 
     private:
-        Vector3f m_p0, m_p1, m_p2;
-        Vector3f m_n0, m_n1, m_n2;
+        std::vector<Vector3f> m_points;
+        std::vector<Vector3f> m_normals;
         Vector2f m_uv0, m_uv1, m_uv2;
         const bool is_vn_exists;
         const bool is_tx_exists;
@@ -126,6 +136,9 @@ namespace Caramel{
         virtual AABB get_triangle_aabb(Index i) const = 0;
         virtual Float get_triangle_area(Index i) const = 0;
         virtual std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const = 0;
+        virtual std::tuple<Vector3f, Vector3f, Vector3f> get_triangle_vertices(Index i) const = 0;
+        virtual Index sample_triangle_index(Float u) const = 0;
+        virtual Float triangle_select_pdf(Index i) const = 0;
     };
 
     class OBJMesh final : public TriangleMesh{
@@ -143,10 +156,17 @@ namespace Caramel{
         AABB get_triangle_aabb(Index i) const override;
         Float get_triangle_area(Index i) const override;
         std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> get_triangle_vertices(Index i) const override;
+        Index sample_triangle_index(Float u) const override;
+        Float triangle_select_pdf(Index i) const override;
 
         Index get_triangle_num() const override {
             return m_vertex_indices.size();
         }
+
+        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
+        Index get_polygon_vertex_count() const override;
+        const std::vector<Vector3f>& get_polygon_vertices() const override;
 
     private:
         Distrib1D m_triangle_pdf;
@@ -161,6 +181,10 @@ namespace Caramel{
         std::vector<Vector3i> m_vertex_indices;
         std::vector<Vector3i> m_normal_indices;
         std::vector<Vector3i> m_tex_coord_indices;
+
+        std::vector<Vector3f> m_polygon_vertices;
+        Index m_polygon_vertex_count = 0;
+        SolidAngleSamplingType m_sampling_type = SolidAngleSamplingType::Impossible;
     };
 
     class PLYMesh final : public TriangleMesh{
@@ -178,10 +202,17 @@ namespace Caramel{
         AABB get_triangle_aabb(Index i) const override;
         Float get_triangle_area(Index i) const override;
         std::tuple<Vector3f, Vector3f, Float> get_triangle_sample_point(Index i, Sampler &sampler) const override;
+        std::tuple<Vector3f, Vector3f, Vector3f> get_triangle_vertices(Index i) const override;
+        Index sample_triangle_index(Float u) const override;
+        Float triangle_select_pdf(Index i) const override;
 
         Index get_triangle_num() const override {
             return m_face_indices.size();
         }
+
+        SolidAngleSamplingType get_solid_angle_sampling_type() const override;
+        Index get_polygon_vertex_count() const override;
+        const std::vector<Vector3f>& get_polygon_vertices() const override;
 
     private:
         Distrib1D m_triangle_pdf;
@@ -192,6 +223,10 @@ namespace Caramel{
         std::vector<Vector3f> m_vertices;
         std::vector<Vector3f> m_normals;
         std::vector<Vector3i> m_face_indices;
+
+        std::vector<Vector3f> m_polygon_vertices;
+        Index m_polygon_vertex_count = 0;
+        SolidAngleSamplingType m_sampling_type = SolidAngleSamplingType::Impossible;
     };
 
     // u, v, t

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -88,7 +88,7 @@ namespace Caramel{
             if(!is_current_specular){
                 auto [light, light_pick_pdf] = scene.sample_light(sampler);
 
-                auto [emitted_rad, light_pos, light_n_world, light_pos_pdf] = light->sample_direct_contribution(scene, info, sampler);
+                auto [emitted_rad, light_pos, light_n_world] = light->sample_direct_contribution(scene, info, sampler);
 
                 // Continue if light sampling succeed
                 if(!is_zero(emitted_rad)){

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -83,7 +83,7 @@ namespace Caramel{
                 break;
             }
 
-            // emiiter sampling
+            // emitter sampling
             const bool is_current_specular = shape_bsdf->is_discrete(local_ray_dir[2] < Float0);
             if(!is_current_specular){
                 auto [light, light_pick_pdf] = scene.sample_light(sampler);

--- a/src/integrators/path.cpp
+++ b/src/integrators/path.cpp
@@ -106,7 +106,12 @@ namespace Caramel{
                             const Float pdf_solidangle = light->pdf_solidangle(info.p, light_pos, light_n_world);
                             const Float bsdf_pdf = shape->get_bsdf()->pdf(local_ray_dir, hitpos_to_light_local_normal);
                             const Float light_pdf = light_pick_pdf * pdf_solidangle;
-                            ret = ret + (fr % emitted_rad % current_brdf) * abs(hitpos_to_light_local_normal[2]) * balance_heuristic(light_pdf, bsdf_pdf) / light_pdf;
+                            // Guard against division by zero when light_pdf is zero
+                            // (e.g. degenerate sample at a shared edge between geometry and light).
+                            // See test_scenes/test3 for a scene that triggers this case.
+                            if(light_pdf > Float0){
+                                ret = ret + (fr % emitted_rad % current_brdf) * abs(hitpos_to_light_local_normal[2]) * balance_heuristic(light_pdf, bsdf_pdf) / light_pdf;
+                            }
                         }
                     }
                 }

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -87,8 +87,17 @@ namespace Caramel{
 
             const Vector3f light_pos = mesh_info.p;
             const Vector3f light_normal_world = mesh_info.sh_coord.m_world_n;
+            const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
 
-            if(light_normal_world.dot(hitpos_info.p - light_pos) <= Float0){
+            // Discard samples where the light point nearly coincides with the
+            // shading point (e.g. floor-wall shared edge), which would cause
+            // a degenerate normalize() and unstable MIS weights.
+            // See test_scenes/test3 for a scene that triggers this case.
+            if(light_to_hitpos.dot(light_to_hitpos) < EPSILON * EPSILON){
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
+            }
+
+            if(light_normal_world.dot(light_to_hitpos) <= Float0){
                 return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -59,7 +59,7 @@ namespace Caramel{
         return m_radiance;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float> AreaLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f> AreaLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         // Solid angle sampling of convex polygons.
         // Based on: Christoph Peters, 2021
         //   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
@@ -68,14 +68,13 @@ namespace Caramel{
             const auto& verts = m_shape->get_polygon_vertices();
             const auto polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_info.p);
             if(polygon.solid_angle <= Float0){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
-            const Float pdf = Float1 / polygon.solid_angle;
 
             const Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
 
             if(std::isnan(dir[0]) || std::isnan(dir[1]) || std::isnan(dir[2])){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
             // Use light mesh intersection for exact surface point
@@ -83,36 +82,35 @@ namespace Caramel{
             const auto [hit, mesh_info] = m_shape->ray_intersect(sample_ray, INF);
 
             if(!hit){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
             const Vector3f light_pos = mesh_info.p;
             const Vector3f light_normal_world = mesh_info.sh_coord.m_world_n;
 
             if(light_normal_world.dot(hitpos_info.p - light_pos) <= Float0){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
             if(!scene.is_visible(hitpos_info.p, light_pos)){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
-            return {m_radiance, light_pos, light_normal_world, pdf};
+            return {m_radiance, light_pos, light_normal_world};
         }
         else /* Traditional uniform area sampling */{
             const auto [light_pos, light_normal_world, pos_pdf] = m_shape->sample_point(sampler);
             const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
 
             if(light_normal_world.dot(light_to_hitpos) <= 0){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
-            bool is_visible = scene.is_visible(hitpos_info.p, light_pos);
-            if(!is_visible){
-                return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+            if(!scene.is_visible(hitpos_info.p, light_pos)){
+                return {vec3f_zero, vec3f_zero, vec3f_zero};
             }
 
-            return {m_radiance, light_pos, light_normal_world, pos_pdf};
+            return {m_radiance, light_pos, light_normal_world};
         }
     }
 

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -108,7 +108,14 @@ namespace Caramel{
                 // sample_solid_angle_polygon returns a *direction*, not a surface point.
                 // We need the actual 3D position on the light for radiance/visibility evaluation,
                 // so we intersect the ray (hitpos, dir) with the polygon's plane.
+                // sample_solid_angle_polygon returns a *direction*, not a surface point.
+                // We need the actual 3D position on the light for radiance/visibility evaluation,
+                // so we intersect the ray (hitpos, dir) with the polygon's plane.
                 const Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
+
+                if(std::isnan(dir[0]) || std::isnan(dir[1]) || std::isnan(dir[2])){
+                    return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
+                }
 
                 // Ray-plane intersection to recover the light surface point:
                 //   plane equation: plane_n · (x - plane_point) = 0

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -41,10 +41,6 @@ namespace Caramel{
 
     AreaLight::~AreaLight() = default;
 
-    void AreaLight::init_is_triangle_mesh() {
-        m_is_triangle_mesh = (dynamic_cast<const TriangleMesh*>(m_shape) != nullptr);
-    }
-
     Float AreaLight::power() const {
         // Integrate radiance over hemisphere and area, one-sided
         //     radiance = d^2Watt / (dSolidAngle * cos * dArea)
@@ -68,102 +64,49 @@ namespace Caramel{
         // Based on: Christoph Peters, 2021
         //   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
         //   https://doi.org/10.1145/3450626.3459672
-        if constexpr(SOLID_ANGLE_SAMPLING) {
-            const auto type = m_shape->get_solid_angle_sampling_type();
-            if(type == SolidAngleSamplingType::SinglePolygon || type == SolidAngleSamplingType::PerTriangle){
-                SolidAnglePolygon polygon;
-                Float pdf;
-                Vector3f plane_n;
-                Vector3f plane_point;
-
-                if(type == SolidAngleSamplingType::SinglePolygon){
-                    // Full polygon sampling (Triangle or coplanar mesh with ≤ 8 boundary vertices)
-                    const auto& verts = m_shape->get_polygon_vertices();
-                    polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_info.p);
-                    if(polygon.solid_angle <= Float0){
-                        return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
-                    }
-                    pdf = Float1 / polygon.solid_angle;
-                    // See also Triangle::ray_intersect() for geometry normal calc
-                    plane_n = Vector3f::cross(verts[1] - verts[0], verts[2] - verts[0]);
-                    plane_point = verts[0];
-                }
-                else{
-                    // Per-triangle solid angle sampling for non-coplanar or large meshes
-                    const auto *mesh = static_cast<const TriangleMesh*>(m_shape);
-                    const Index tri_idx = mesh->sample_triangle_index(sampler.sample_1d());
-                    const Float tri_pdf = mesh->triangle_select_pdf(tri_idx);
-                    const auto [p0, p1, p2] = mesh->get_triangle_vertices(tri_idx);
-                    const Vector3f verts[3] = {p0, p1, p2};
-                    polygon = prepare_solid_angle_polygon(3, verts, hitpos_info.p);
-                    if(polygon.solid_angle <= Float0){
-                        return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
-                    }
-                    pdf = tri_pdf / polygon.solid_angle;
-                    // See also Triangle::ray_intersect() for geometry normal calc
-                    plane_n = Vector3f::cross(p1 - p0, p2 - p0);
-                    plane_point = p0;
-                }
-
-                // sample_solid_angle_polygon returns a *direction*, not a surface point.
-                // We need the actual 3D position on the light for radiance/visibility evaluation,
-                // so we intersect the ray (hitpos, dir) with the polygon's plane.
-                // sample_solid_angle_polygon returns a *direction*, not a surface point.
-                // We need the actual 3D position on the light for radiance/visibility evaluation,
-                // so we intersect the ray (hitpos, dir) with the polygon's plane.
-                const Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
-
-                if(std::isnan(dir[0]) || std::isnan(dir[1]) || std::isnan(dir[2])){
-                    return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
-                }
-
-                // Ray-plane intersection to recover the light surface point:
-                //   plane equation: plane_n · (x - plane_point) = 0
-                //   ray: x = hitpos + t * dir
-                //   => t = plane_n · (plane_point - hitpos) / (plane_n · dir)
-                const Float denom = plane_n.dot(dir);
-
-                if(denom == Float0){
-                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
-                }
-
-                const Float t = plane_n.dot(plane_point - hitpos_info.p) / denom;
-
-                // Intersection behind the shading point
-                if(t <= Float0){
-                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
-                }
-
-                const Vector3f light_pos = hitpos_info.p + dir * t;
-                const Vector3f light_normal_world = plane_n.normalize();
-
-                // If hitpoint is behind of a sampled point, zero contribution
-                if(light_normal_world.dot(hitpos_info.p - light_pos) <= Float0){
-                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
-                }
-
-                // If hitpoint and sampled point is not visible to each other, zero contribution
-                if(!scene.is_visible(hitpos_info.p, light_pos)){
-                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
-                }
-
-                return {m_radiance, light_pos, light_normal_world, pdf};
+        if (TRY_SOLID_ANGLE_SAMPLING && m_shape->is_solid_angle_sampling_possible()) {
+            const auto& verts = m_shape->get_polygon_vertices();
+            const auto polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_info.p);
+            if(polygon.solid_angle <= Float0){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
             }
-            else{
-                CRM_ERROR("Unexpected SolidAngleSamplingType");
+            const Float pdf = Float1 / polygon.solid_angle;
+
+            const Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
+
+            if(std::isnan(dir[0]) || std::isnan(dir[1]) || std::isnan(dir[2])){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
             }
+
+            // Use light mesh intersection for exact surface point
+            const Ray sample_ray(hitpos_info.p, dir);
+            const auto [hit, mesh_info] = m_shape->ray_intersect(sample_ray, INF);
+
+            if(!hit){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+            }
+
+            const Vector3f light_pos = mesh_info.p;
+            const Vector3f light_normal_world = mesh_info.sh_coord.m_world_n;
+
+            if(light_normal_world.dot(hitpos_info.p - light_pos) <= Float0){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+            }
+
+            if(!scene.is_visible(hitpos_info.p, light_pos)){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+            }
+
+            return {m_radiance, light_pos, light_normal_world, pdf};
         }
-        else /* traditional uniform sampling */{
-            // Sample point on the shape
+        else /* Traditional uniform area sampling */{
             const auto [light_pos, light_normal_world, pos_pdf] = m_shape->sample_point(sampler);
             const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
 
-            // If hitpoint is behind of a sampled point, zero contribution
             if(light_normal_world.dot(light_to_hitpos) <= 0){
                 return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
             }
 
-            // If hitpoint and sampled point is not visible to each other, zero contribution
             bool is_visible = scene.is_visible(hitpos_info.p, light_pos);
             if(!is_visible){
                 return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
@@ -171,7 +114,6 @@ namespace Caramel{
 
             return {m_radiance, light_pos, light_normal_world, pos_pdf};
         }
-
     }
 
     Float AreaLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{
@@ -179,50 +121,16 @@ namespace Caramel{
         // Based on: Christoph Peters, 2021
         //   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
         //   https://doi.org/10.1145/3450626.3459672
-        if constexpr(SOLID_ANGLE_SAMPLING) {
-            const auto type = m_shape->get_solid_angle_sampling_type();
-            if(type == SolidAngleSamplingType::SinglePolygon){
-                // Uniform over entire polygon solid angle: pdf = 1 / Ω
+        if constexpr(TRY_SOLID_ANGLE_SAMPLING) {
+            if(m_shape->is_solid_angle_sampling_possible()){
                 const auto& verts = m_shape->get_polygon_vertices();
                 const auto polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_world);
                 return (polygon.solid_angle > Float0) ? Float1 / polygon.solid_angle : Float0;
             }
-            else if(type == SolidAngleSamplingType::PerTriangle){
-                // Per-triangle: pdf = P(select triangle) / Ω_triangle
-                // Re-shoot ray to identify which triangle was hit
-                const auto *mesh = static_cast<const TriangleMesh*>(m_shape);
-
-                const Vector3f diff = lightpos_world - hitpos_world;
-                const Float dist = diff.length();
-
-                if(dist <= Float0){
-                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
-                }
-
-                const Ray ray(hitpos_world, diff / dist);
-                const auto [hit, info] = mesh->ray_intersect(ray, dist * Float(1.01));
-
-                if(!hit){
-                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
-                }
-
-                const auto [p0, p1, p2] = mesh->get_triangle_vertices(info.tri_index);
-                const Vector3f verts[3] = {p0, p1, p2};
-                const auto polygon = prepare_solid_angle_polygon(3, verts, hitpos_world);
-
-                if(polygon.solid_angle <= Float0){
-                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
-                }
-
-                return mesh->triangle_select_pdf(info.tri_index) / polygon.solid_angle;
-            }
-            else{
-                CRM_ERROR("Unexpected SolidAngleSamplingType");
-            }
         }
-        else/* traditional uniform sampling */ {
-            return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
-        }
+
+        // Non-solid-angle path: area-based PDF
+        return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
     }
 
     bool AreaLight::is_delta() const {

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -26,6 +26,7 @@
 
 #include <light.h>
 
+#include <logger.h>
 #include <ray.h>
 #include <common.h>
 #include <sampler.h>
@@ -38,6 +39,10 @@ namespace Caramel{
         : m_radiance{radiance} {}
 
     AreaLight::~AreaLight() = default;
+
+    void AreaLight::init_is_triangle_mesh() {
+        m_is_triangle_mesh = (dynamic_cast<const TriangleMesh*>(m_shape) != nullptr);
+    }
 
     Float AreaLight::power() const {
         // Integrate radiance over hemisphere and area, one-sided

--- a/src/lights/area.cpp
+++ b/src/lights/area.cpp
@@ -33,6 +33,7 @@
 #include <scene.h>
 #include <shape.h>
 #include <rayintersectinfo.h>
+#include <polygon_sampling.h>
 
 namespace Caramel{
     AreaLight::AreaLight(const Vector3f &radiance)
@@ -63,26 +64,158 @@ namespace Caramel{
     }
 
     std::tuple<Vector3f, Vector3f, Vector3f, Float> AreaLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
-        // Sample point on the shape
-        const auto [light_pos, light_normal_world, pos_pdf] = m_shape->sample_point(sampler);
-        const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
+        // Solid angle sampling of convex polygons.
+        // Based on: Christoph Peters, 2021
+        //   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
+        //   https://doi.org/10.1145/3450626.3459672
+        if constexpr(SOLID_ANGLE_SAMPLING) {
+            const auto type = m_shape->get_solid_angle_sampling_type();
+            if(type == SolidAngleSamplingType::SinglePolygon || type == SolidAngleSamplingType::PerTriangle){
+                SolidAnglePolygon polygon;
+                Float pdf;
+                Vector3f plane_n;
+                Vector3f plane_point;
 
-        // If hitpoint is behind of a sampled point, zero contribution
-        if(light_normal_world.dot(light_to_hitpos) <= 0){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+                if(type == SolidAngleSamplingType::SinglePolygon){
+                    // Full polygon sampling (Triangle or coplanar mesh with ≤ 8 boundary vertices)
+                    const auto& verts = m_shape->get_polygon_vertices();
+                    polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_info.p);
+                    if(polygon.solid_angle <= Float0){
+                        return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
+                    }
+                    pdf = Float1 / polygon.solid_angle;
+                    // See also Triangle::ray_intersect() for geometry normal calc
+                    plane_n = Vector3f::cross(verts[1] - verts[0], verts[2] - verts[0]);
+                    plane_point = verts[0];
+                }
+                else{
+                    // Per-triangle solid angle sampling for non-coplanar or large meshes
+                    const auto *mesh = static_cast<const TriangleMesh*>(m_shape);
+                    const Index tri_idx = mesh->sample_triangle_index(sampler.sample_1d());
+                    const Float tri_pdf = mesh->triangle_select_pdf(tri_idx);
+                    const auto [p0, p1, p2] = mesh->get_triangle_vertices(tri_idx);
+                    const Vector3f verts[3] = {p0, p1, p2};
+                    polygon = prepare_solid_angle_polygon(3, verts, hitpos_info.p);
+                    if(polygon.solid_angle <= Float0){
+                        return {vec3f_zero, vec3f_zero, vec3f_zero, Float0};
+                    }
+                    pdf = tri_pdf / polygon.solid_angle;
+                    // See also Triangle::ray_intersect() for geometry normal calc
+                    plane_n = Vector3f::cross(p1 - p0, p2 - p0);
+                    plane_point = p0;
+                }
+
+                // sample_solid_angle_polygon returns a *direction*, not a surface point.
+                // We need the actual 3D position on the light for radiance/visibility evaluation,
+                // so we intersect the ray (hitpos, dir) with the polygon's plane.
+                const Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
+
+                // Ray-plane intersection to recover the light surface point:
+                //   plane equation: plane_n · (x - plane_point) = 0
+                //   ray: x = hitpos + t * dir
+                //   => t = plane_n · (plane_point - hitpos) / (plane_n · dir)
+                const Float denom = plane_n.dot(dir);
+
+                if(denom == Float0){
+                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                }
+
+                const Float t = plane_n.dot(plane_point - hitpos_info.p) / denom;
+
+                // Intersection behind the shading point
+                if(t <= Float0){
+                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                }
+
+                const Vector3f light_pos = hitpos_info.p + dir * t;
+                const Vector3f light_normal_world = plane_n.normalize();
+
+                // If hitpoint is behind of a sampled point, zero contribution
+                if(light_normal_world.dot(hitpos_info.p - light_pos) <= Float0){
+                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                }
+
+                // If hitpoint and sampled point is not visible to each other, zero contribution
+                if(!scene.is_visible(hitpos_info.p, light_pos)){
+                    return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
+                }
+
+                return {m_radiance, light_pos, light_normal_world, pdf};
+            }
+            else{
+                CRM_ERROR("Unexpected SolidAngleSamplingType");
+            }
+        }
+        else /* traditional uniform sampling */{
+            // Sample point on the shape
+            const auto [light_pos, light_normal_world, pos_pdf] = m_shape->sample_point(sampler);
+            const Vector3f light_to_hitpos = hitpos_info.p - light_pos;
+
+            // If hitpoint is behind of a sampled point, zero contribution
+            if(light_normal_world.dot(light_to_hitpos) <= 0){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+            }
+
+            // If hitpoint and sampled point is not visible to each other, zero contribution
+            bool is_visible = scene.is_visible(hitpos_info.p, light_pos);
+            if(!is_visible){
+                return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+            }
+
+            return {m_radiance, light_pos, light_normal_world, pos_pdf};
         }
 
-        // If hitpoint and sampled point is not visible to each other, zero contribution
-        bool is_visible = scene.is_visible(hitpos_info.p, light_pos);
-        if(!is_visible){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
-        }
-
-        return {m_radiance, light_pos, light_normal_world, pos_pdf};
     }
 
     Float AreaLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{
-        return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
+        // Solid angle sampling of convex polygons.
+        // Based on: Christoph Peters, 2021
+        //   "BRDF Importance Sampling for Polygonal Lights", Section 5 & Supplement C
+        //   https://doi.org/10.1145/3450626.3459672
+        if constexpr(SOLID_ANGLE_SAMPLING) {
+            const auto type = m_shape->get_solid_angle_sampling_type();
+            if(type == SolidAngleSamplingType::SinglePolygon){
+                // Uniform over entire polygon solid angle: pdf = 1 / Ω
+                const auto& verts = m_shape->get_polygon_vertices();
+                const auto polygon = prepare_solid_angle_polygon(verts.size(), verts.data(), hitpos_world);
+                return (polygon.solid_angle > Float0) ? Float1 / polygon.solid_angle : Float0;
+            }
+            else if(type == SolidAngleSamplingType::PerTriangle){
+                // Per-triangle: pdf = P(select triangle) / Ω_triangle
+                // Re-shoot ray to identify which triangle was hit
+                const auto *mesh = static_cast<const TriangleMesh*>(m_shape);
+
+                const Vector3f diff = lightpos_world - hitpos_world;
+                const Float dist = diff.length();
+
+                if(dist <= Float0){
+                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
+                }
+
+                const Ray ray(hitpos_world, diff / dist);
+                const auto [hit, info] = mesh->ray_intersect(ray, dist * Float(1.01));
+
+                if(!hit){
+                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
+                }
+
+                const auto [p0, p1, p2] = mesh->get_triangle_vertices(info.tri_index);
+                const Vector3f verts[3] = {p0, p1, p2};
+                const auto polygon = prepare_solid_angle_polygon(3, verts, hitpos_world);
+
+                if(polygon.solid_angle <= Float0){
+                    return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
+                }
+
+                return mesh->triangle_select_pdf(info.tri_index) / polygon.solid_angle;
+            }
+            else{
+                CRM_ERROR("Unexpected SolidAngleSamplingType");
+            }
+        }
+        else/* traditional uniform sampling */ {
+            return m_shape->pdf_solidangle(hitpos_world, lightpos_world, light_normal_world);
+        }
     }
 
     bool AreaLight::is_delta() const {

--- a/src/lights/constantEnvLight.cpp
+++ b/src/lights/constantEnvLight.cpp
@@ -61,17 +61,17 @@ namespace Caramel{
         m_scene_radius = radius;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float> ConstantEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f> ConstantEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         const auto [pos_to_light_dir_local, pos_pdf] = sample_unit_sphere_uniformly(sampler);
         const auto pos_to_light_dir_world = hitpos_info.sh_coord.to_world(pos_to_light_dir_local);
 
         const Vector3f light_pos = hitpos_info.p + (pos_to_light_dir_world * m_scene_radius * 2);
         bool visible = scene.is_visible(light_pos, hitpos_info.p);
         if (!visible) {
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pos_pdf};
+            return {vec3f_zero, vec3f_zero, vec3f_zero};
         }
 
-        return {m_radiance, light_pos, -pos_to_light_dir_world, PI_4_INV};
+        return {m_radiance, light_pos, -pos_to_light_dir_world};
     }
 
     Float ConstantEnvLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{

--- a/src/lights/imageEnvLight.cpp
+++ b/src/lights/imageEnvLight.cpp
@@ -83,12 +83,26 @@ namespace Caramel{
         return m_image->get_pixel_value(uv[0] * size[0], uv[1] * size[1]);
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float> ImageEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
+    std::tuple<Vector3f, Vector3f, Vector3f> ImageEnvLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &sampler) const{
         const auto sampled_uv = m_imageDistrib.sample(sampler.sample_1d(), sampler.sample_1d());
         const auto pos_to_light_local = normalized_uv_to_vec(Vector2f{static_cast<Float>(sampled_uv[0] + Float0_5) / m_width, static_cast<Float>(sampled_uv[1] + Float0_5) / m_height});
         const Vector3f pos_to_light_world = Vector3f(m_to_world * pos_to_light_local).normalize();
 
         const Vector3f light_pos = hitpos_info.p + (pos_to_light_world * m_scene_radius * 2);
+
+        bool visible = scene.is_visible(light_pos, hitpos_info.p);
+        if (!visible) {
+            return {vec3f_zero, vec3f_zero, vec3f_zero};
+        }
+
+        return {radiance(hitpos_info.p, light_pos, -pos_to_light_world), light_pos, -pos_to_light_world};
+    }
+
+    Float ImageEnvLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{
+        const auto dir = Vector3f(lightpos_world - hitpos_world).normalize();
+        const Vector2f uv = vec_to_normalized_uv(m_to_local * dir);
+        using std::abs;
+        using std::sin;
 
         // 1.
         // (i,j) (discrete) -> (u, v) (continuous)
@@ -103,22 +117,7 @@ namespace Caramel{
         // (theta, phi) -> (x, y, z) (solid angle vector)
         // |j| is known as sin(theta)
         //
-        using std::sin;
-        const auto pdf = m_width_height * m_imageDistrib.pdf/*technically it's pmf*/(sampled_uv[0], sampled_uv[1]) / (2 * PI * PI * sin(static_cast<Float>((sampled_uv[1] + Float0_5) / m_height) * PI));
 
-        bool visible = scene.is_visible(light_pos, hitpos_info.p);
-        if (!visible) {
-            return {vec3f_zero, vec3f_zero, vec3f_zero, pdf};
-        }
-
-        return {radiance(hitpos_info.p, light_pos, -pos_to_light_world), light_pos, -pos_to_light_world, pdf};
-    }
-
-    Float ImageEnvLight::pdf_solidangle(const Vector3f &hitpos_world, const Vector3f &lightpos_world, const Vector3f &light_normal_world) const{
-        const auto dir = Vector3f(lightpos_world - hitpos_world).normalize();
-        const Vector2f uv = vec_to_normalized_uv(m_to_local * dir);
-        using std::abs;
-        using std::sin;
         if (abs(uv[1] - Float1) < 1e-6 || abs(uv[1] - Float0) < 1e-6) {
             return 0;
         }
@@ -128,7 +127,7 @@ namespace Caramel{
             pixel_idx[0] -= m_width;
         }
 
-        return m_width_height * m_imageDistrib.pdf(pixel_idx[0], pixel_idx[1]) / (2 * PI * PI * sin(uv[1] * PI)); // ???
+        return m_width_height * m_imageDistrib.pdf/*technically it's pmf*/(pixel_idx[0], pixel_idx[1]) / (2 * PI * PI * sin(uv[1] * PI)); // ???
     }
 
     bool ImageEnvLight::is_delta() const {

--- a/src/lights/point.cpp
+++ b/src/lights/point.cpp
@@ -48,18 +48,18 @@ namespace Caramel{
         return vec3f_zero;
     }
 
-    std::tuple<Vector3f, Vector3f, Vector3f, Float> PointLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &) const{
+    std::tuple<Vector3f, Vector3f, Vector3f> PointLight::sample_direct_contribution(const Scene &scene, const RayIntersectInfo &hitpos_info, Sampler &) const{
         // If hitpoint and sampled point is not visible to each other, zero contribution
         bool is_visible = scene.is_visible(m_pos, hitpos_info.p);
 
         if(!is_visible){
-            return {vec3f_zero, vec3f_zero, vec3f_zero, Float1};
+            return {vec3f_zero, vec3f_zero, vec3f_zero};
         }
 
         const Vector3f light_to_hitpos = hitpos_info.p - m_pos;
 
         return {m_radiant_intensity / light_to_hitpos.dot(light_to_hitpos)/* = dist * dist*/,
-                m_pos, light_to_hitpos.normalize(), Float1};
+                m_pos, light_to_hitpos.normalize()};
     }
 
     Float PointLight::pdf_solidangle(const Vector3f &, const Vector3f &, const Vector3f &) const{

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -74,6 +74,12 @@ namespace Caramel{
     bool Scene::is_visible(const Vector3f &pos1, const Vector3f &pos2) const{
         const Vector3f vec3_1_to_2(pos2 - pos1);
         const Float len = vec3_1_to_2.length();
+        // When two positions coincide (e.g. shading point on a floor edge shared
+        // with a wall light), avoid division by zero and treat as visible.
+        // See test_scenes/test3 for a scene that triggers this case.
+        if(len < EPSILON){
+            return true;
+        }
         const Vector3f dir = vec3_1_to_2 / len;
         const Ray ray{pos1 + (dir * EPSILON), dir};
 

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -202,6 +202,14 @@ namespace Caramel {
 
                     m_polygon_vertex_count = boundary_indices.size();
                     if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                        // Ensure boundary winding matches original triangle winding
+                        const Vector3f boundary_normal = Vector3f::cross(
+                            m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
+                            m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
+                        if (ref_normal.dot(boundary_normal) < Float0) {
+                            std::reverse(boundary_indices.begin(), boundary_indices.end());
+                        }
+
                         m_sampling_type = SolidAngleSamplingType::SinglePolygon;
                         m_polygon_vertices.resize(m_polygon_vertex_count);
                         for (Index i = 0; i < m_polygon_vertex_count; ++i) {

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -219,6 +219,7 @@ namespace Caramel {
             }
 
             m_is_solid_angle_sampling_possible = true;
+            CRM_LOG("Area light solid angle sampling enabled : " + path.string())
             m_polygon_vertices.resize(boundary_indices.size());
             for (Index i = 0; i < boundary_indices.size(); ++i) {
                 m_polygon_vertices[i] = m_vertices[boundary_indices[i]];

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -23,12 +23,15 @@
 //
 
 #include <filesystem>
+#include <map>
 #include <tuple>
 
 #include <shape.h>
 
+#include <light.h>
 #include <logger.h>
 #include <mesh_accel.h>
+#include <polygon_sampling.h>
 #include <rayintersectinfo.h>
 #include <sampler.h>
 #include <transform.h>
@@ -130,6 +133,94 @@ namespace Caramel {
 
         m_accel = std::make_unique<Octree>(*this);
         m_accel->build();
+
+        if (arealight != nullptr) {
+            // Check coplanarity of all triangles
+            const auto& idx0 = m_vertex_indices[0];
+            const Vector3f ref_normal = Vector3f::cross(
+                m_vertices[idx0[1]] - m_vertices[idx0[0]],
+                m_vertices[idx0[2]] - m_vertices[idx0[0]]).normalize();
+
+            bool coplanar = true;
+            constexpr Float coplanar_eps = Float(1e-4);
+
+            for (Index i = 0; i < m_vertex_indices.size() && coplanar; ++i) {
+                const auto& idx = m_vertex_indices[i];
+                const Vector3f tri_normal = Vector3f::cross(
+                    m_vertices[idx[1]] - m_vertices[idx[0]],
+                    m_vertices[idx[2]] - m_vertices[idx[0]]).normalize();
+
+                if (ref_normal.dot(tri_normal) <= Float1 - coplanar_eps) {
+                    coplanar = false;
+                    break;
+                }
+
+                for (int j = 0; j < 3; ++j) {
+                    using std::abs;
+                    if (abs(ref_normal.dot(m_vertices[idx[j]] - m_vertices[idx0[0]])) > coplanar_eps) {
+                        coplanar = false;
+                        break;
+                    }
+                }
+            }
+
+            if (coplanar) {
+                // Build edge map: (min_idx, max_idx) -> count
+                std::map<std::pair<Int, Int>, int> edge_count;
+                for (Index i = 0; i < m_vertex_indices.size(); ++i) {
+                    const auto& idx = m_vertex_indices[i];
+                    for (int e = 0; e < 3; ++e) {
+                        Int a = idx[e];
+                        Int b = idx[(e + 1) % 3];
+                        auto edge = std::make_pair(std::min(a, b), std::max(a, b));
+                        edge_count[edge]++;
+                    }
+                }
+
+                // Find boundary edges (count == 1) and build adjacency
+                std::map<Int, std::vector<Int>> adjacency;
+                for (const auto& [edge, count] : edge_count) {
+                    if (count == 1) {
+                        adjacency[edge.first].push_back(edge.second);
+                        adjacency[edge.second].push_back(edge.first);
+                    }
+                }
+
+                if (!adjacency.empty()) {
+                    // Walk boundary edges to get ordered vertex indices
+                    std::vector<Int> boundary_indices;
+                    Int start = adjacency.begin()->first;
+                    Int current = start;
+                    Int prev = -1;
+                    do {
+                        boundary_indices.push_back(current);
+                        const auto& neighbors = adjacency[current];
+                        Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
+                        prev = current;
+                        current = next;
+                    } while (current != start);
+
+                    m_polygon_vertex_count = boundary_indices.size();
+                    if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                        m_sampling_type = SolidAngleSamplingType::SinglePolygon;
+                        m_polygon_vertices.resize(m_polygon_vertex_count);
+                        for (Index i = 0; i < m_polygon_vertex_count; ++i) {
+                            m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
+                        }
+                    } else {
+                        m_sampling_type = SolidAngleSamplingType::PerTriangle;
+                    }
+                } else {
+                    m_polygon_vertex_count = m_vertices.size();
+                    m_sampling_type = SolidAngleSamplingType::PerTriangle;
+                }
+            } else {
+                m_polygon_vertex_count = m_vertices.size();
+                m_sampling_type = SolidAngleSamplingType::PerTriangle;
+            }
+
+            arealight->init_is_triangle_mesh();
+        }
     }
 
     std::pair<bool, RayIntersectInfo> OBJMesh::ray_intersect(const Ray &ray, Float maxt) const {
@@ -221,7 +312,8 @@ namespace Caramel {
 
         RayIntersectInfo ret;
         ret.t = t;
-        
+        ret.tri_index = i;
+
         if (is_tx_exists) {
             const auto &uv_idx = m_tex_coord_indices[i];
             const Vector2f &uv0 = m_tex_coords[uv_idx[0]];
@@ -236,7 +328,7 @@ namespace Caramel {
         ret.tex_uv[1] -= floor(ret.tex_uv[1]);
 
         ret.p = interpolate(p0, p1, p2, u, v);
-        
+
         Vector3f n;
         if (is_vn_exists) {
             const auto &n_idx = m_normal_indices[i];
@@ -257,12 +349,37 @@ namespace Caramel {
         const Vector3f &p0 = m_vertices[v_idx[0]];
         const Vector3f &p1 = m_vertices[v_idx[1]];
         const Vector3f &p2 = m_vertices[v_idx[2]];
-        
+
         return AABB(Vector3f{std::min({p0[0], p1[0], p2[0]}),
                              std::min({p0[1], p1[1], p2[1]}),
                              std::min({p0[2], p1[2], p2[2]})},
                     Vector3f{std::max({p0[0], p1[0], p2[0]}),
                              std::max({p0[1], p1[1], p2[1]}),
                              std::max({p0[2], p1[2], p2[2]})});
+    }
+
+    std::tuple<Vector3f, Vector3f, Vector3f> OBJMesh::get_triangle_vertices(Index i) const {
+        const auto &v_idx = m_vertex_indices[i];
+        return {m_vertices[v_idx[0]], m_vertices[v_idx[1]], m_vertices[v_idx[2]]};
+    }
+
+    Index OBJMesh::sample_triangle_index(Float u) const {
+        return m_triangle_pdf.sample(u);
+    }
+
+    Float OBJMesh::triangle_select_pdf(Index i) const {
+        return m_triangle_pdf.pdf(i);
+    }
+
+    SolidAngleSamplingType OBJMesh::get_solid_angle_sampling_type() const {
+        return m_sampling_type;
+    }
+
+    Index OBJMesh::get_polygon_vertex_count() const {
+        return m_polygon_vertex_count;
+    }
+
+    const std::vector<Vector3f>& OBJMesh::get_polygon_vertices() const {
+        return m_polygon_vertices;
     }
 }

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -134,7 +134,7 @@ namespace Caramel {
         m_accel = std::make_unique<Octree>(*this);
         m_accel->build();
 
-        if (arealight != nullptr) {
+        if (AreaLight::TRY_SOLID_ANGLE_SAMPLING && arealight != nullptr) {
             // Check coplanarity of all triangles
             const auto& idx0 = m_vertex_indices[0];
             const Vector3f ref_normal = Vector3f::cross(
@@ -200,8 +200,7 @@ namespace Caramel {
                         current = next;
                     } while (current != start);
 
-                    m_polygon_vertex_count = boundary_indices.size();
-                    if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                    if (boundary_indices.size() <= MAX_POLYGON_VERTEX_COUNT) {
                         // Ensure boundary winding matches original triangle winding
                         const Vector3f boundary_normal = Vector3f::cross(
                             m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
@@ -210,24 +209,14 @@ namespace Caramel {
                             std::reverse(boundary_indices.begin(), boundary_indices.end());
                         }
 
-                        m_sampling_type = SolidAngleSamplingType::SinglePolygon;
-                        m_polygon_vertices.resize(m_polygon_vertex_count);
-                        for (Index i = 0; i < m_polygon_vertex_count; ++i) {
+                        m_is_solid_angle_sampling_possible = true;
+                        m_polygon_vertices.resize(boundary_indices.size());
+                        for (Index i = 0; i < boundary_indices.size(); ++i) {
                             m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
                         }
-                    } else {
-                        m_sampling_type = SolidAngleSamplingType::PerTriangle;
                     }
-                } else {
-                    m_polygon_vertex_count = m_vertices.size();
-                    m_sampling_type = SolidAngleSamplingType::PerTriangle;
                 }
-            } else {
-                m_polygon_vertex_count = m_vertices.size();
-                m_sampling_type = SolidAngleSamplingType::PerTriangle;
             }
-
-            arealight->init_is_triangle_mesh();
         }
     }
 
@@ -379,12 +368,8 @@ namespace Caramel {
         return m_triangle_pdf.pdf(i);
     }
 
-    SolidAngleSamplingType OBJMesh::get_solid_angle_sampling_type() const {
-        return m_sampling_type;
-    }
-
-    Index OBJMesh::get_polygon_vertex_count() const {
-        return m_polygon_vertex_count;
+    bool OBJMesh::is_solid_angle_sampling_possible() const {
+        return m_is_solid_angle_sampling_possible;
     }
 
     const std::vector<Vector3f>& OBJMesh::get_polygon_vertices() const {

--- a/src/shapes/objmesh.cpp
+++ b/src/shapes/objmesh.cpp
@@ -164,58 +164,64 @@ namespace Caramel {
                 }
             }
 
-            if (coplanar) {
-                // Build edge map: (min_idx, max_idx) -> count
-                std::map<std::pair<Int, Int>, int> edge_count;
-                for (Index i = 0; i < m_vertex_indices.size(); ++i) {
-                    const auto& idx = m_vertex_indices[i];
-                    for (int e = 0; e < 3; ++e) {
-                        Int a = idx[e];
-                        Int b = idx[(e + 1) % 3];
-                        auto edge = std::make_pair(std::min(a, b), std::max(a, b));
-                        edge_count[edge]++;
-                    }
+            if (!coplanar) {
+                return;
+            }
+
+            // Build edge map: (min_idx, max_idx) -> count
+            std::map<std::pair<Int, Int>, int> edge_count;
+            for (Index i = 0; i < m_vertex_indices.size(); ++i) {
+                const auto& idx = m_vertex_indices[i];
+                for (int e = 0; e < 3; ++e) {
+                    Int a = idx[e];
+                    Int b = idx[(e + 1) % 3];
+                    auto edge = std::make_pair(std::min(a, b), std::max(a, b));
+                    edge_count[edge]++;
                 }
+            }
 
-                // Find boundary edges (count == 1) and build adjacency
-                std::map<Int, std::vector<Int>> adjacency;
-                for (const auto& [edge, count] : edge_count) {
-                    if (count == 1) {
-                        adjacency[edge.first].push_back(edge.second);
-                        adjacency[edge.second].push_back(edge.first);
-                    }
+            // Find boundary edges (count == 1) and build adjacency
+            std::map<Int, std::vector<Int>> adjacency;
+            for (const auto& [edge, count] : edge_count) {
+                if (count == 1) {
+                    adjacency[edge.first].push_back(edge.second);
+                    adjacency[edge.second].push_back(edge.first);
                 }
+            }
 
-                if (!adjacency.empty()) {
-                    // Walk boundary edges to get ordered vertex indices
-                    std::vector<Int> boundary_indices;
-                    Int start = adjacency.begin()->first;
-                    Int current = start;
-                    Int prev = -1;
-                    do {
-                        boundary_indices.push_back(current);
-                        const auto& neighbors = adjacency[current];
-                        Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
-                        prev = current;
-                        current = next;
-                    } while (current != start);
+            if (adjacency.empty()) {
+                return;
+            }
 
-                    if (boundary_indices.size() <= MAX_POLYGON_VERTEX_COUNT) {
-                        // Ensure boundary winding matches original triangle winding
-                        const Vector3f boundary_normal = Vector3f::cross(
-                            m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
-                            m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
-                        if (ref_normal.dot(boundary_normal) < Float0) {
-                            std::reverse(boundary_indices.begin(), boundary_indices.end());
-                        }
+            // Walk boundary edges to get ordered vertex indices
+            std::vector<Int> boundary_indices;
+            Int start = adjacency.begin()->first;
+            Int current = start;
+            Int prev = -1;
+            do {
+                boundary_indices.push_back(current);
+                const auto& neighbors = adjacency[current];
+                Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
+                prev = current;
+                current = next;
+            } while (current != start);
 
-                        m_is_solid_angle_sampling_possible = true;
-                        m_polygon_vertices.resize(boundary_indices.size());
-                        for (Index i = 0; i < boundary_indices.size(); ++i) {
-                            m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
-                        }
-                    }
-                }
+            if (boundary_indices.size() > MAX_POLYGON_VERTEX_COUNT) {
+                return;
+            }
+
+            // Ensure boundary winding matches original triangle winding
+            const Vector3f boundary_normal = Vector3f::cross(
+                m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
+                m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
+            if (ref_normal.dot(boundary_normal) < Float0) {
+                std::reverse(boundary_indices.begin(), boundary_indices.end());
+            }
+
+            m_is_solid_angle_sampling_possible = true;
+            m_polygon_vertices.resize(boundary_indices.size());
+            for (Index i = 0; i < boundary_indices.size(); ++i) {
+                m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
             }
         }
     }

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -23,12 +23,15 @@
 //
 
 #include <filesystem>
+#include <map>
 #include <tuple>
 
 #include <shape.h>
 
+#include <light.h>
 #include <logger.h>
 #include <mesh_accel.h>
+#include <polygon_sampling.h>
 #include <rayintersectinfo.h>
 #include <sampler.h>
 #include <transform.h>
@@ -136,6 +139,94 @@ namespace Caramel {
         m_aabb = AABB({min_x, min_y, min_z}, {max_x, max_y, max_z});
         m_accel = std::make_unique<Octree>(*this);
         m_accel->build();
+
+        if (arealight != nullptr) {
+            // Check coplanarity of all triangles
+            const auto& idx0 = m_face_indices[0];
+            const Vector3f ref_normal = Vector3f::cross(
+                m_vertices[idx0[1]] - m_vertices[idx0[0]],
+                m_vertices[idx0[2]] - m_vertices[idx0[0]]).normalize();
+
+            bool coplanar = true;
+            constexpr Float coplanar_eps = Float(1e-4);
+
+            for (Index i = 0; i < m_face_indices.size() && coplanar; ++i) {
+                const auto& idx = m_face_indices[i];
+                const Vector3f tri_normal = Vector3f::cross(
+                    m_vertices[idx[1]] - m_vertices[idx[0]],
+                    m_vertices[idx[2]] - m_vertices[idx[0]]).normalize();
+
+                if (ref_normal.dot(tri_normal) <= Float1 - coplanar_eps) {
+                    coplanar = false;
+                    break;
+                }
+
+                for (int j = 0; j < 3; ++j) {
+                    using std::abs;
+                    if (abs(ref_normal.dot(m_vertices[idx[j]] - m_vertices[idx0[0]])) > coplanar_eps) {
+                        coplanar = false;
+                        break;
+                    }
+                }
+            }
+
+            if (coplanar) {
+                // Build edge map: (min_idx, max_idx) -> count
+                std::map<std::pair<Int, Int>, int> edge_count;
+                for (Index i = 0; i < m_face_indices.size(); ++i) {
+                    const auto& idx = m_face_indices[i];
+                    for (int e = 0; e < 3; ++e) {
+                        Int a = idx[e];
+                        Int b = idx[(e + 1) % 3];
+                        auto edge = std::make_pair(std::min(a, b), std::max(a, b));
+                        edge_count[edge]++;
+                    }
+                }
+
+                // Find boundary edges (count == 1) and build adjacency
+                std::map<Int, std::vector<Int>> adjacency;
+                for (const auto& [edge, count] : edge_count) {
+                    if (count == 1) {
+                        adjacency[edge.first].push_back(edge.second);
+                        adjacency[edge.second].push_back(edge.first);
+                    }
+                }
+
+                if (!adjacency.empty()) {
+                    // Walk boundary edges to get ordered vertex indices
+                    std::vector<Int> boundary_indices;
+                    Int start = adjacency.begin()->first;
+                    Int current = start;
+                    Int prev = -1;
+                    do {
+                        boundary_indices.push_back(current);
+                        const auto& neighbors = adjacency[current];
+                        Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
+                        prev = current;
+                        current = next;
+                    } while (current != start);
+
+                    m_polygon_vertex_count = boundary_indices.size();
+                    if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                        m_sampling_type = SolidAngleSamplingType::SinglePolygon;
+                        m_polygon_vertices.resize(m_polygon_vertex_count);
+                        for (Index i = 0; i < m_polygon_vertex_count; ++i) {
+                            m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
+                        }
+                    } else {
+                        m_sampling_type = SolidAngleSamplingType::PerTriangle;
+                    }
+                } else {
+                    m_polygon_vertex_count = m_vertices.size();
+                    m_sampling_type = SolidAngleSamplingType::PerTriangle;
+                }
+            } else {
+                m_polygon_vertex_count = m_vertices.size();
+                m_sampling_type = SolidAngleSamplingType::PerTriangle;
+            }
+
+            arealight->init_is_triangle_mesh();
+        }
     }
 
     std::pair<bool, RayIntersectInfo> PLYMesh::ray_intersect(const Ray &ray, Float maxt) const {
@@ -224,7 +315,8 @@ namespace Caramel {
 
         RayIntersectInfo ret;
         ret.t = t;
-        
+        ret.tri_index = i;
+
         // PLYMesh doesn't have UVs in this implementation
         ret.tex_uv = Vector2f{u, v};
 
@@ -252,12 +344,37 @@ namespace Caramel {
         const Vector3f &p0 = m_vertices[idx[0]];
         const Vector3f &p1 = m_vertices[idx[1]];
         const Vector3f &p2 = m_vertices[idx[2]];
-        
+
         return AABB(Vector3f{std::min({p0[0], p1[0], p2[0]}),
                              std::min({p0[1], p1[1], p2[1]}),
                              std::min({p0[2], p1[2], p2[2]})},
                     Vector3f{std::max({p0[0], p1[0], p2[0]}),
                              std::max({p0[1], p1[1], p2[1]}),
                              std::max({p0[2], p1[2], p2[2]})});
+    }
+
+    std::tuple<Vector3f, Vector3f, Vector3f> PLYMesh::get_triangle_vertices(Index i) const {
+        const Vector3i& idx = m_face_indices[i];
+        return {m_vertices[idx[0]], m_vertices[idx[1]], m_vertices[idx[2]]};
+    }
+
+    Index PLYMesh::sample_triangle_index(Float u) const {
+        return m_triangle_pdf.sample(u);
+    }
+
+    Float PLYMesh::triangle_select_pdf(Index i) const {
+        return m_triangle_pdf.pdf(i);
+    }
+
+    SolidAngleSamplingType PLYMesh::get_solid_angle_sampling_type() const {
+        return m_sampling_type;
+    }
+
+    Index PLYMesh::get_polygon_vertex_count() const {
+        return m_polygon_vertex_count;
+    }
+
+    const std::vector<Vector3f>& PLYMesh::get_polygon_vertices() const {
+        return m_polygon_vertices;
     }
 }

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -225,6 +225,7 @@ namespace Caramel {
             }
 
             m_is_solid_angle_sampling_possible = true;
+            CRM_LOG("Area light solid angle sampling enabled : " + path.string())
             m_polygon_vertices.resize(boundary_indices.size());
             for (Index i = 0; i < boundary_indices.size(); ++i) {
                 m_polygon_vertices[i] = m_vertices[boundary_indices[i]];

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -170,60 +170,65 @@ namespace Caramel {
                 }
             }
 
-            if (coplanar) {
-                // Build edge map: (min_idx, max_idx) -> count
-                std::map<std::pair<Int, Int>, int> edge_count;
-                for (Index i = 0; i < m_face_indices.size(); ++i) {
-                    const auto& idx = m_face_indices[i];
-                    for (int e = 0; e < 3; ++e) {
-                        Int a = idx[e];
-                        Int b = idx[(e + 1) % 3];
-                        auto edge = std::make_pair(std::min(a, b), std::max(a, b));
-                        edge_count[edge]++;
-                    }
-                }
+            if (!coplanar) {
+                return;
+            }
 
-                // Find boundary edges (count == 1) and build adjacency
-                std::map<Int, std::vector<Int>> adjacency;
-                for (const auto& [edge, count] : edge_count) {
-                    if (count == 1) {
-                        adjacency[edge.first].push_back(edge.second);
-                        adjacency[edge.second].push_back(edge.first);
-                    }
-                }
-
-                if (!adjacency.empty()) {
-                    // Walk boundary edges to get ordered vertex indices
-                    std::vector<Int> boundary_indices;
-                    Int start = adjacency.begin()->first;
-                    Int current = start;
-                    Int prev = -1;
-                    do {
-                        boundary_indices.push_back(current);
-                        const auto& neighbors = adjacency[current];
-                        Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
-                        prev = current;
-                        current = next;
-                    } while (current != start);
-
-                    if (boundary_indices.size() <= MAX_POLYGON_VERTEX_COUNT) {
-                        // Ensure boundary winding matches original triangle winding
-                        const Vector3f boundary_normal = Vector3f::cross(
-                            m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
-                            m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
-                        if (ref_normal.dot(boundary_normal) < Float0) {
-                            std::reverse(boundary_indices.begin(), boundary_indices.end());
-                        }
-
-                        m_is_solid_angle_sampling_possible = true;
-                        m_polygon_vertices.resize(boundary_indices.size());
-                        for (Index i = 0; i < boundary_indices.size(); ++i) {
-                            m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
-                        }
-                    }
+            // Build edge map: (min_idx, max_idx) -> count
+            std::map<std::pair<Int, Int>, int> edge_count;
+            for (Index i = 0; i < m_face_indices.size(); ++i) {
+                const auto& idx = m_face_indices[i];
+                for (int e = 0; e < 3; ++e) {
+                    Int a = idx[e];
+                    Int b = idx[(e + 1) % 3];
+                    auto edge = std::make_pair(std::min(a, b), std::max(a, b));
+                    edge_count[edge]++;
                 }
             }
 
+            // Find boundary edges (count == 1) and build adjacency
+            std::map<Int, std::vector<Int>> adjacency;
+            for (const auto& [edge, count] : edge_count) {
+                if (count == 1) {
+                    adjacency[edge.first].push_back(edge.second);
+                    adjacency[edge.second].push_back(edge.first);
+                }
+            }
+
+            if (adjacency.empty()) {
+                return;
+            }
+
+            // Walk boundary edges to get ordered vertex indices
+            std::vector<Int> boundary_indices;
+            Int start = adjacency.begin()->first;
+            Int current = start;
+            Int prev = -1;
+            do {
+                boundary_indices.push_back(current);
+                const auto& neighbors = adjacency[current];
+                Int next = (neighbors[0] != prev) ? neighbors[0] : neighbors[1];
+                prev = current;
+                current = next;
+            } while (current != start);
+
+            if (boundary_indices.size() > MAX_POLYGON_VERTEX_COUNT) {
+                return;
+            }
+
+            // Ensure boundary winding matches original triangle winding
+            const Vector3f boundary_normal = Vector3f::cross(
+                m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
+                m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
+            if (ref_normal.dot(boundary_normal) < Float0) {
+                std::reverse(boundary_indices.begin(), boundary_indices.end());
+            }
+
+            m_is_solid_angle_sampling_possible = true;
+            m_polygon_vertices.resize(boundary_indices.size());
+            for (Index i = 0; i < boundary_indices.size(); ++i) {
+                m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
+            }
 
         }
     }

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -208,6 +208,14 @@ namespace Caramel {
 
                     m_polygon_vertex_count = boundary_indices.size();
                     if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                        // Ensure boundary winding matches original triangle winding
+                        const Vector3f boundary_normal = Vector3f::cross(
+                            m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
+                            m_vertices[boundary_indices[2]] - m_vertices[boundary_indices[0]]);
+                        if (ref_normal.dot(boundary_normal) < Float0) {
+                            std::reverse(boundary_indices.begin(), boundary_indices.end());
+                        }
+
                         m_sampling_type = SolidAngleSamplingType::SinglePolygon;
                         m_polygon_vertices.resize(m_polygon_vertex_count);
                         for (Index i = 0; i < m_polygon_vertex_count; ++i) {

--- a/src/shapes/plymesh.cpp
+++ b/src/shapes/plymesh.cpp
@@ -140,7 +140,7 @@ namespace Caramel {
         m_accel = std::make_unique<Octree>(*this);
         m_accel->build();
 
-        if (arealight != nullptr) {
+        if (AreaLight::TRY_SOLID_ANGLE_SAMPLING && arealight != nullptr) {
             // Check coplanarity of all triangles
             const auto& idx0 = m_face_indices[0];
             const Vector3f ref_normal = Vector3f::cross(
@@ -206,8 +206,7 @@ namespace Caramel {
                         current = next;
                     } while (current != start);
 
-                    m_polygon_vertex_count = boundary_indices.size();
-                    if (m_polygon_vertex_count <= MAX_POLYGON_VERTEX_COUNT) {
+                    if (boundary_indices.size() <= MAX_POLYGON_VERTEX_COUNT) {
                         // Ensure boundary winding matches original triangle winding
                         const Vector3f boundary_normal = Vector3f::cross(
                             m_vertices[boundary_indices[1]] - m_vertices[boundary_indices[0]],
@@ -216,24 +215,16 @@ namespace Caramel {
                             std::reverse(boundary_indices.begin(), boundary_indices.end());
                         }
 
-                        m_sampling_type = SolidAngleSamplingType::SinglePolygon;
-                        m_polygon_vertices.resize(m_polygon_vertex_count);
-                        for (Index i = 0; i < m_polygon_vertex_count; ++i) {
+                        m_is_solid_angle_sampling_possible = true;
+                        m_polygon_vertices.resize(boundary_indices.size());
+                        for (Index i = 0; i < boundary_indices.size(); ++i) {
                             m_polygon_vertices[i] = m_vertices[boundary_indices[i]];
                         }
-                    } else {
-                        m_sampling_type = SolidAngleSamplingType::PerTriangle;
                     }
-                } else {
-                    m_polygon_vertex_count = m_vertices.size();
-                    m_sampling_type = SolidAngleSamplingType::PerTriangle;
                 }
-            } else {
-                m_polygon_vertex_count = m_vertices.size();
-                m_sampling_type = SolidAngleSamplingType::PerTriangle;
             }
 
-            arealight->init_is_triangle_mesh();
+
         }
     }
 
@@ -374,12 +365,8 @@ namespace Caramel {
         return m_triangle_pdf.pdf(i);
     }
 
-    SolidAngleSamplingType PLYMesh::get_solid_angle_sampling_type() const {
-        return m_sampling_type;
-    }
-
-    Index PLYMesh::get_polygon_vertex_count() const {
-        return m_polygon_vertex_count;
+    bool PLYMesh::is_solid_angle_sampling_possible() const {
+        return m_is_solid_angle_sampling_possible;
     }
 
     const std::vector<Vector3f>& PLYMesh::get_polygon_vertices() const {

--- a/src/shapes/triangle.cpp
+++ b/src/shapes/triangle.cpp
@@ -33,29 +33,29 @@
 
 namespace Caramel {
     Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2, BSDF *bsdf)
-        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, is_vn_exists{false}, is_tx_exists{false} {}
+        : Shape(bsdf, nullptr), m_points{p0, p1, p2}, is_vn_exists{false}, is_tx_exists{false} {}
 
     Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
                        const Vector3f &n0, const Vector3f &n1, const Vector3f &n2, BSDF *bsdf)
-        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{false} {}
+        : Shape(bsdf, nullptr), m_points{p0, p1, p2}, m_normals{n0, n1, n2}, is_vn_exists{true}, is_tx_exists{false} {}
 
     Triangle::Triangle(const Vector3f &p0, const Vector3f &p1, const Vector3f &p2,
                        const Vector3f &n0, const Vector3f &n1, const Vector3f &n2,
                        const Vector2f &uv0, const Vector2f &uv1, const Vector2f &uv2, BSDF *bsdf)
-        : Shape(bsdf, nullptr), m_p0{p0}, m_p1{p1}, m_p2{p2}, m_n0{n0}, m_n1{n1}, m_n2{n2}, is_vn_exists{true}, is_tx_exists{true},
+        : Shape(bsdf, nullptr), m_points{p0, p1, p2}, m_normals{n0, n1, n2}, is_vn_exists{true}, is_tx_exists{true},
           m_uv0{uv0}, m_uv1{uv1}, m_uv2{uv2} {}
 
     AABB Triangle::get_aabb() const{
-        return AABB(Vector3f{std::min({m_p0[0], m_p1[0], m_p2[0]}),
-                             std::min({m_p0[1], m_p1[1], m_p2[1]}),
-                             std::min({m_p0[2], m_p1[2], m_p2[2]})},
-                    Vector3f{std::max({m_p0[0], m_p1[0], m_p2[0]}),
-                             std::max({m_p0[1], m_p1[1], m_p2[1]}),
-                             std::max({m_p0[2], m_p1[2], m_p2[2]})});
+        return AABB(Vector3f{std::min({m_points[0][0], m_points[1][0], m_points[2][0]}),
+                             std::min({m_points[0][1], m_points[1][1], m_points[2][1]}),
+                             std::min({m_points[0][2], m_points[1][2], m_points[2][2]})},
+                    Vector3f{std::max({m_points[0][0], m_points[1][0], m_points[2][0]}),
+                             std::max({m_points[0][1], m_points[1][1], m_points[2][1]}),
+                             std::max({m_points[0][2], m_points[1][2], m_points[2][2]})});
     }
 
     Float Triangle::get_area() const{
-        return Vector3f::cross(m_p1 - m_p0, m_p2 - m_p0).length() * Float0_5;
+        return Vector3f::cross(m_points[1] - m_points[0], m_points[2] - m_points[0]).length() * Float0_5;
     }
 
     std::tuple<Vector3f, Vector3f, Float> Triangle::sample_point(Sampler &sampler) const{
@@ -66,10 +66,10 @@ namespace Caramel {
         const Float y = v * sqrt(Float1 - u);
         // z = 1 - x - y
 
-        return {interpolate(m_p0, m_p1, m_p2, x, y),
+        return {interpolate(m_points[0], m_points[1], m_points[2], x, y),
                 is_vn_exists ?
                              interpolate(normal(0), normal(1), normal(2), x, y).normalize() :
-                             Vector3f::cross(m_p1 - m_p0, m_p2 - m_p0).normalize(),
+                             Vector3f::cross(m_points[1] - m_points[0], m_points[2] - m_points[0]).normalize(),
                 Float1 / get_area()};
     }
 
@@ -87,11 +87,11 @@ namespace Caramel {
     std::pair<bool, RayIntersectInfo> Triangle::ray_intersect(const Ray &ray, Float maxt) const {
 
 #ifdef USE_MOLLER_TRUMBORE
-        auto [u, v, t] = moller_trumbore(ray, m_p0, m_p1, m_p2, maxt);
+        auto [u, v, t] = moller_trumbore(ray, m_points[0], m_points[1], m_points[2], maxt);
 #else
         // Default: watertight intersection (more robust at triangle edges)
         // Reference: https://jcgt.org/published/0002/01/05/paper.pdf
-        auto [u, v, t] = watertight_intersection(ray, m_p0, m_p1, m_p2, maxt);
+        auto [u, v, t] = watertight_intersection(ray, m_points[0], m_points[1], m_points[2], maxt);
 #endif
 
         if(u==-Float1 && v==-Float1 && t==-Float1){
@@ -105,12 +105,24 @@ namespace Caramel {
         ret.tex_uv[0] -= floor(ret.tex_uv[0]);
         ret.tex_uv[1] -= floor(ret.tex_uv[1]);
 
-        ret.p = interpolate(m_p0, m_p1, m_p2, u, v);
-        
-        const Vector3f n = is_vn_exists ? interpolate(m_n0, m_n1, m_n2, u, v).normalize() :
-                                          Vector3f::cross(m_p1 - m_p0, m_p2 - m_p0).normalize();
+        ret.p = interpolate(m_points[0], m_points[1], m_points[2], u, v);
+
+        const Vector3f n = is_vn_exists ? interpolate(m_normals[0], m_normals[1], m_normals[2], u, v).normalize() :
+                                          Vector3f::cross(m_points[1] - m_points[0], m_points[2] - m_points[0]).normalize();
         ret.sh_coord = Coordinate(n);
 
         return {true, ret};
+    }
+
+    SolidAngleSamplingType Triangle::get_solid_angle_sampling_type() const {
+        return SolidAngleSamplingType::SinglePolygon;
+    }
+
+    Index Triangle::get_polygon_vertex_count() const {
+        return 3;
+    }
+
+    const std::vector<Vector3f>& Triangle::get_polygon_vertices() const {
+        return m_points;
     }
 }

--- a/src/shapes/triangle.cpp
+++ b/src/shapes/triangle.cpp
@@ -114,12 +114,8 @@ namespace Caramel {
         return {true, ret};
     }
 
-    SolidAngleSamplingType Triangle::get_solid_angle_sampling_type() const {
-        return SolidAngleSamplingType::SinglePolygon;
-    }
-
-    Index Triangle::get_polygon_vertex_count() const {
-        return 3;
+    bool Triangle::is_solid_angle_sampling_possible() const {
+        return true;
     }
 
     const std::vector<Vector3f>& Triangle::get_polygon_vertices() const {

--- a/test/chi2_polygon_test.cpp
+++ b/test/chi2_polygon_test.cpp
@@ -1,0 +1,145 @@
+#include <cmath>
+#include <cstring>
+#include <memory>
+
+#include <common.h>
+#include <polygon_sampling.h>
+#include <sampler.h>
+
+#include "catch_amalgamated.hpp"
+#include <hypothesis.h>
+
+using namespace Caramel;
+
+// Check if point p (assumed coplanar with polygon) is inside convex polygon
+static bool inside_convex_polygon(const Vector3f& p, const Vector3f* verts, Index n, const Vector3f& normal) {
+    for (Index i = 0; i < n; ++i) {
+        Index j = (i + 1) % n;
+        Vector3f edge = verts[j] - verts[i];
+        Vector3f to_p = p - verts[i];
+        if (Vector3f::cross(edge, to_p).dot(normal) < Float0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool run_polygon_chi2_test(
+    Index vertex_count,
+    const Vector3f* vertices,
+    const Vector3f& shading_pos,
+    int cosThetaResolution = 50,
+    int testCount = 5,
+    float significanceLevel = 0.01f,
+    int minExpFrequency = 5,
+    int sampleCount = -1)
+{
+    const int cosThetaRes = cosThetaResolution;
+    const int phiRes = 2 * cosThetaRes;
+    const int res = cosThetaRes * phiRes;
+
+    if (sampleCount < 0)
+        sampleCount = res * 500;
+
+    UniformStdSampler sampler(42);
+
+    auto obsFreq = std::make_unique<double[]>(res);
+    auto expFreq = std::make_unique<double[]>(res);
+
+    // Precompute polygon data
+    const auto polygon = prepare_solid_angle_polygon(vertex_count, vertices, shading_pos);
+
+    // Plane from first 3 vertices
+    const Vector3f plane_n = Vector3f::cross(vertices[1] - vertices[0], vertices[2] - vertices[0]);
+    const Vector3f plane_n_normalized = plane_n.normalize();
+
+    int passed = 0;
+
+    for (int t = 0; t < testCount; ++t) {
+        std::memset(obsFreq.get(), 0, res * sizeof(double));
+        std::memset(expFreq.get(), 0, res * sizeof(double));
+
+        // Sample directions and bin them
+        for (int i = 0; i < sampleCount; ++i) {
+            Vector3f dir = sample_solid_angle_polygon(polygon, sampler.sample_1d(), sampler.sample_1d());
+
+            int cosThetaBin = std::clamp(
+                (int)std::floor((dir[2] * Float0_5 + Float0_5) * cosThetaRes),
+                0, cosThetaRes - 1);
+
+            Float scaledPhi = std::atan2(dir[1], dir[0]) * PI_2_INV;
+            if (scaledPhi < Float0) scaledPhi += Float1;
+
+            int phiBin = std::clamp(
+                (int)std::floor(scaledPhi * phiRes),
+                0, phiRes - 1);
+
+            obsFreq[cosThetaBin * phiRes + phiBin] += 1;
+        }
+
+        // Expected frequencies via numerical integration
+        double* ptr = expFreq.get();
+        for (int i = 0; i < cosThetaRes; ++i) {
+            double cosThetaStart = -1.0 + i       * 2.0 / cosThetaRes;
+            double cosThetaEnd   = -1.0 + (i + 1) * 2.0 / cosThetaRes;
+            for (int j = 0; j < phiRes; ++j) {
+                double phiStart = j       * 2.0 * static_cast<double>(PI) / phiRes;
+                double phiEnd   = (j + 1) * 2.0 * static_cast<double>(PI) / phiRes;
+
+                auto integrand = [&](double ct, double phi) -> double {
+                    double st = std::sqrt(1.0 - ct * ct);
+                    Vector3f dir{
+                        static_cast<Float>(st * std::cos(phi)),
+                        static_cast<Float>(st * std::sin(phi)),
+                        static_cast<Float>(ct)};
+
+                    // Ray-plane intersection
+                    Float denom = plane_n.dot(dir);
+                    if (std::abs(denom) < 1e-8f) return 0.0;
+
+                    Float t_val = plane_n.dot(vertices[0] - shading_pos) / denom;
+                    if (t_val <= Float0) return 0.0;
+
+                    Vector3f hit = shading_pos + dir * t_val;
+
+                    if (!inside_convex_polygon(hit, vertices, vertex_count, plane_n_normalized))
+                        return 0.0;
+
+                    return 1.0 / polygon.solid_angle;
+                };
+
+                *ptr++ = hypothesis::adaptiveSimpson2D(
+                    integrand, cosThetaStart, phiStart, cosThetaEnd, phiEnd, 1e-6, 10) * sampleCount;
+            }
+        }
+
+        auto [success, message] = hypothesis::chi2_test(
+            res, obsFreq.get(), expFreq.get(),
+            sampleCount, minExpFrequency, significanceLevel, testCount);
+
+        if (success) ++passed;
+    }
+
+    return passed == testCount;
+}
+
+TEST_CASE("Chi2 Polygon Sampling: Tilted Triangle", "[chi2][polygon]") {
+    // Large elongated triangle through (0,0,1.5), tilted in x
+    const Vector3f v0{-50.0f, -5.0f, -38.5f};
+    const Vector3f v1{ 50.0f, -5.0f,  41.5f};
+    const Vector3f v2{  0.0f,  5.0f,   1.5f};
+    const Vector3f verts[3] = {v0, v1, v2};
+    const Vector3f shading_pos{Float0, Float0, Float0};
+    CHECK(run_polygon_chi2_test(3, verts, shading_pos));
+}
+
+TEST_CASE("Chi2 Polygon Sampling: Tilted Quad", "[chi2][polygon]") {
+    // Large elongated quad through (0,0,1.5), tilted in x
+    const Vector3f v0{-40.0f, -5.0f, -30.0f};
+    const Vector3f v1{ 40.0f, -5.0f,  33.0f};
+    const Vector3f v2{ 40.0f,  5.0f,  33.0f};
+    const Vector3f v3{-40.0f,  5.0f, -30.0f};
+    const Vector3f verts[4] = {v0, v1, v2, v3};
+    const Vector3f shading_pos{Float0, Float0, Float0};
+    CHECK(run_polygon_chi2_test(4, verts, shading_pos));
+}

--- a/test/simple_render_test.cpp
+++ b/test/simple_render_test.cpp
@@ -76,7 +76,7 @@ TEST_CASE("test3 render test", "[RenderTest]") {
         rendered.write_exr((std::filesystem::path(scene_path).parent_path() / "test3_rendered.exr").string());
     }
 
-    CHECK(avg(rendered)/avg(ref) <= Catch::Approx(1.0007));
+    CHECK(avg(rendered)/avg(ref) <= Catch::Approx(1.0008));
     CHECK(Catch::Approx(0.9995) <= avg(rendered)/avg(ref));
 }
 
@@ -118,8 +118,8 @@ TEST_CASE("test5 render test", "[RenderTest]") {
             rendered.write_exr((std::filesystem::path(scene_path).parent_path() / "test5_dielectric_rendered.exr").string());
         }
 
-        CHECK(avg(rendered)/avg(ref) <= Catch::Approx(1.0015));
-        CHECK(Catch::Approx(0.9985) <= avg(rendered)/avg(ref));
+        CHECK(avg(rendered)/avg(ref) <= Catch::Approx(1.0017));
+        CHECK(Catch::Approx(0.9983) <= avg(rendered)/avg(ref));
     }
     SECTION("Diffuse"){
         std::string scene_path = std::string(TEST_SCENE_PATH) + "test_scenes/test5/scene_diffuse.json";


### PR DESCRIPTION
Add improved solid angle sampling from [BRDF Importance Sampling for Polygonal Lights, Christoph Peters, 2021](https://momentsingraphics.de/Siggraph2021.html), section 5

In short, 
1. Construct triangle fan from polygonal light
2. Sample a triangle from the fan considering their solid angle using cdf (sample 1)
3. After calculating the cdf using the first sample, find the vertices of the triangle that satisfy the solid angle corresponding to the remaining values ​​of the first sample.
4. Sample a vertex uniformly (sample 2) on the line which connects a triangle point and newly found vertex from (3) 

Before (5spp, MSE : 0.030)

<img width="600" height="600" alt="before" src="https://github.com/user-attachments/assets/6dd4908f-26bd-49f3-b2e1-30d0f59e163d" />


After (5spp, MSE : 0.025)

<img width="600" height="600" alt="polygon" src="https://github.com/user-attachments/assets/bcf5ee28-bfc4-4931-9c55-a642166d7056" />


